### PR TITLE
feat: replace Exegol with lightweight aida-pentest container

### DIFF
--- a/Docs/INSTALLATION.md
+++ b/Docs/INSTALLATION.md
@@ -16,8 +16,9 @@ Before we start, make sure you have:
 | **Git** | Any | `git --version` |
 
 Also needed:
-- **Exegol** container ([Install guide](https://docs.exegol.com/first-install/))
 - **An AI client** that supports MCP — Claude Code or Kimi CLI recommended (see Step 5)
+
+> **Exegol users:** AIDA supports Exegol as an alternative container. You will be asked at first launch.
 
 ---
 
@@ -38,10 +39,25 @@ The easiest way - Docker Compose handles everything:
 ./start.sh
 ```
 
+**On first run**, you will be asked to choose your pentesting container:
+
+```
+  [1] aida-pentest
+      Built-in, managed by AIDA — starts automatically with ./start.sh
+      Size: ~2 GB  |  Tools: nmap, ffuf, gobuster, sqlmap, nikto...
+
+  [2] Exegol
+      Third-party container — requires separate install: https://docs.exegol.com
+      Size: ~20-40 GB  |  Tools: ~400+ security tools
+```
+
+Both options are fully supported. Press Enter or `1` for `aida-pentest` (default). If you're already an Exegol user, select `2` to keep using it. You can switch between them anytime in Settings.
+
 This starts:
 - **PostgreSQL** on port `5432` - The database
 - **Backend API** on port `8000` - FastAPI server
 - **Frontend** on port `5173` - React dashboard
+- **aida-pentest** - Pentesting container (if selected above)
 
 ### Step 3: Verify It Works
 
@@ -51,24 +67,46 @@ You should see the AIDA dashboard.
 
 ---
 
-## Step 4: Install and Setup Exegol
+## Step 4: Pentesting Container
 
-**Install Exegol:** Follow the official guide → https://docs.exegol.com/first-install
+AIDA supports two pentesting containers. You chose one during Step 2 — here's what to do next for each.
 
-**Start the container:**
+### Option 1 — aida-pentest (built-in)
+
+If you selected `aida-pentest`, you're done. The container started automatically as part of `docker compose up` — no extra steps needed.
+
+**Disk space:** ~2 GB.
+
+**What's included:** nmap, ffuf, gobuster, sqlmap, nikto, dirb, hydra, whatweb, subfinder, dnsx, openssl + Python libs (impacket, scapy, pwntools, paramiko, requests...) + SecLists wordlists.
+
+This covers all the essential tools for a typical assessment. If you need additional tools, you can install them directly inside the container at any time:
+
 ```bash
+docker exec -it aida-pentest bash
+# then install whatever you need, e.g.:
+apt-get install -y metasploit-framework
+```
+
+Or switch to Exegol (Option 2) if you want 400+ tools pre-installed out of the box.
+
+### Option 2 — Exegol
+
+If you selected Exegol (or want to switch to it), you need to install it separately:
+
+```bash
+# Install Exegol
+pip install exegol
+
+# Pull an image (web is sufficient, full is 40+ GB)
+exegol install web
+
+# Start a container named "aida"
 exegol start aida
 ```
 
-When it asks which image to use, select ```web``` or the ```full``` one
+Then in AIDA Settings, make sure your default container is set to `exegol-aida`.
 
-Yeah, I know 40GB is a lot. I'm working on a lighter alternative.
-
-**Configure AIDA:**
-
-1. Go to http://localhost:5173/settings 
-2. Under **Tools**, check if your Exegol container is detected
-3. Set your default container name to `exegol-aida` (or whatever you named it)
+> **Switching containers:** You can change your container preference anytime in **Settings → Container**. This affects new assessments; existing ones keep their assigned container.
 
 ---
 
@@ -273,9 +311,9 @@ Run through this checklist:
 | Check | How | Expected |
 |-------|-----|----------|
 | Platform running | http://localhost:5173 | Dashboard loads |
-| API healthy |http://localhost:8000/health | `{"status": "healthy"}` |
+| API healthy | http://localhost:8000/health | `{"status": "healthy"}` |
 | Database connected | Check backend logs | No connection errors |
-| Exegol container | `docker ps \| grep exegol` | Container running |
+| Pentest container | `docker ps \| grep aida-pentest` or `docker ps \| grep exegol` | Container running |
 | MCP server | Check AI client | AIDA tools visible |
 
 

--- a/Docs/PrePrompt.txt
+++ b/Docs/PrePrompt.txt
@@ -24,13 +24,25 @@ You are a cybersecurity & pentesting expert conducting full‑scope assessments 
 
 * The browser agent can: navigate, click, type, submit forms, capture screenshots
 
-## **Execution Tools in Exegol**
+## **Pentesting Container**
 
-Three MCP tools run inside the Exegol container:
+You have access to a dedicated pentesting container
+
+**Wordlists (pre-installed):**
+- `/usr/share/dirb/wordlists/common.txt` — fast, everyday fuzzing
+- `/usr/share/dirb/wordlists/big.txt` — extended dirb list
+- `/usr/share/dirbuster/directory-list-2.3-medium.txt` — DirBuster medium
+- `/usr/share/dirbuster/directory-list-2.3-big.txt` — DirBuster big
+- `/usr/share/seclists/Discovery/Web-Content/raft-small-words.txt`
+- `/usr/share/seclists/Discovery/Web-Content/raft-medium-directories.txt`
+- `/usr/share/seclists/Discovery/DNS/subdomains-top1million-5000.txt`
+- `/usr/share/seclists/Discovery/DNS/subdomains-top1million-20000.txt`
 
 * `execute(command)` — Shell commands and all pentesting tools (nmap, sqlmap, ffuf, hydra, etc.)
 * `python_exec(code)` — Python code via stdin (no shell escaping). Use for scripting, impacket, requests, scapy, custom payloads.
 * `http_request(method, url, ...)` — Structured HTTP requests. Use for internal network targets, proxy routing (Burp), SSL bypass, or when curl escaping is painful.
+
+> If a tool is missing, use `tool_help()` to check availability, or install it with `execute("apt-get install -y <tool>")` / `execute("pip3 install <lib>")`.
 
 ## **Workspace**
 
@@ -40,7 +52,7 @@ You are working in the assessment's workspace directory. Your current working di
 - Use relative paths (e.g., `loot/credentials.txt`)
 - Or absolute paths from current directory
 
-**For Exegol commands** (MCP `execute()`, `python_exec()`, `http_request()`):
+**For container commands** (MCP `execute()`, `python_exec()`, `http_request()`):
 - Commands run inside the container with all pentesting tools
 - The container workspace is automatically mapped
 - Credential placeholders (e.g. `{{TOKEN}}`) are auto-substituted in all 3 tools
@@ -58,7 +70,7 @@ You are working in the assessment's workspace directory. Your current working di
 Each assessment is unique.
 Adapt tools, techniques, and phase order based on the target’s technologies, exposed services, and new discoveries.
 Switch phases whenever needed (e.g., return to recon after new info).
-Always choose the most appropriate Exegol MCP tools and commands for the context.
+Always choose the most appropriate MCP tools and commands for the context.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 <p align="center">
   <img src="https://img.shields.io/badge/License-AGPL_v3-blue" alt="License">
   <img src="https://img.shields.io/badge/MCP-Compatible-green" alt="MCP">
-  <img src="https://img.shields.io/badge/Docker-Exegol-orange" alt="Exegol">
+  <img src="https://img.shields.io/badge/Container-aida--pentest-orange" alt="aida-pentest">
   <img src="https://img.shields.io/badge/Version-1.0.0--alpha-purple" alt="Version">
 </p>
 
@@ -29,7 +29,7 @@
 **AIDA** connects AI assistants to a real pentesting environment. Instead of just *talking* about security testing, your AI can actually *do* it.
 
 Here's the deal:
--  **Exegol Docker container** with 400+ security tools (nmap, sqlmap, ffuf, nuclei...)
+-  **Your choice of pentesting container** — use the built-in `aida-pentest` (~2 GB, starts automatically, covers all the essential tools) or bring your own [Exegol](https://github.com/ThePorgs/Exegol) container (400+ tools, ~20-40 GB). You pick at first launch — and can switch anytime.
 -  **MCP integration** that works with *any* AI client (Claude, Gemini, GPT, Antigravity...)
 -  **Web dashboard** to track findings, commands, and progress
 -  **Structured workflow** from recon to exploitation
@@ -52,7 +52,7 @@ Without execution capabilities, security testing becomes a tedious back-and-fort
 
 **AIDA changes this** by connecting AI directly to a professional pentesting environment:
 
-- 🔧 **Direct Execution** - 400+ tools in Exegol (nmap, sqlmap, ffuf, nuclei...)
+- 🔧 **Direct Execution** - Built-in pentesting environment (nmap, sqlmap, ffuf, nuclei...)
 - 🧠 **Persistent Memory** - Full context maintained across sessions in structured database
 - 📝 **Auto Documentation** - Findings tracked as cards with severity, proof, and technical analysis
 - ⛓️ **Attack Chains** - AI connects dots between discoveries to build multi-step exploits
@@ -85,8 +85,9 @@ Without execution capabilities, security testing becomes a tedious back-and-fort
 
 ### Prerequisites
 
-- **Docker Desktop** - For running Exegol and the platform
+- **Docker Desktop** - To run the platform
 - **An AI Client** - Claude Desktop, Claude Code, Gemini CLI, Antigravity... pick your favorite
+- **Pentesting container** - `aida-pentest` built-in (default, ~2 GB) or [Exegol](https://github.com/ThePorgs/Exegol) if you need 400+ tools
 
 
 ```bash
@@ -101,7 +102,7 @@ cd AIDA
 open http://localhost:5173
 ```
 
-That's it. The platform is running.
+On first run, `./start.sh` will ask which pentesting container you want to use — the built-in `aida-pentest` or your own Exegol container. Default is `aida-pentest`. You can change this anytime in Settings.
 
 ### Connect Your AI
 
@@ -199,7 +200,7 @@ RECON
    list_recon        - View recon data
 
 EXECUTION
-   execute           - Run any command in Exegol
+   execute           - Run any command in the pentesting container
    scan              - Quick scans (nmap, gobuster, ffuf...)
    subdomain_enum    - Find subdomains
    ssl_analysis      - Check SSL/TLS
@@ -227,6 +228,8 @@ AIDA/
 ├── frontend/            # React dashboard
 │   ├── src/pages/       # Dashboard, Assessments, Settings...
 │   └── src/components/  # Reusable UI components
+├── pentest/             # Built-in pentesting container (aida-pentest)
+│   └── Dockerfile       # Ubuntu 22.04 + nmap, ffuf, gobuster, sqlmap...
 ├── Docs/                # AI prompts and methodology
 ├── aida.py              # CLI launcher
 ├── start.sh             # Start the platform
@@ -276,7 +279,6 @@ AIDA is actively developed. Want to contribute?
 
 **Planned Features:**
 
-- Build our docker image
 - Frontend redesign with flat, professional UI
 - OWASP testing guidelines integration
 - Enhanced phase workflow system
@@ -301,9 +303,9 @@ Contact: **Vasco0x4@proton.me**
 
 ## Credits
 
-- [**Exegol**](https://github.com/ThePorgs/Exegol) - The pentesting Docker environment
 - [**Anthropic MCP**](https://modelcontextprotocol.io/) - The protocol that makes this possible
-- The security community for all the amazing tools
+- The security community for all the amazing open-source tools
+- [**Exegol**](https://github.com/ThePorgs/Exegol) - Supported as an alternative container for advanced users
 
 ---
 <p align="center">

--- a/backend/.env.docker
+++ b/backend/.env.docker
@@ -40,10 +40,11 @@ DATABASE_URL=postgresql://aida:aida@postgres:5432/aida_assessments
 BACKEND_CORS_ORIGINS=http://localhost:5173,http://localhost:3000
 
 # ========================================
-# CONTAINER CONFIGURATION (Exegol pentesting environment)
+# CONTAINER CONFIGURATION
+# Default: aida-pentest (built-in). Set to your Exegol container name if using Exegol.
 # ========================================
 CONTAINER_WORKSPACE_BASE=/workspace
-DEFAULT_CONTAINER_NAME=exegol-aida
+DEFAULT_CONTAINER_NAME=aida-pentest
 COMMAND_TIMEOUT=300
 
 # ========================================

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -29,10 +29,11 @@ DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}
 BACKEND_CORS_ORIGINS=http://localhost:5173,http://localhost:3000
 
 # ========================================
-# CONTAINER CONFIGURATION (Exegol pentesting environment)
+# CONTAINER CONFIGURATION
+# Default: aida-pentest (built-in). Set to your Exegol container name if using Exegol.
 # ========================================
 CONTAINER_WORKSPACE_BASE=/workspace
-DEFAULT_CONTAINER_NAME=exegol-aida
+DEFAULT_CONTAINER_NAME=aida-pentest
 COMMAND_TIMEOUT=300
 
 # ========================================

--- a/backend/config.py
+++ b/backend/config.py
@@ -31,9 +31,12 @@ class Settings(BaseSettings):
     # For production, set BACKEND_CORS_ORIGINS in .env to specific origins
     BACKEND_CORS_ORIGINS: str = "*"
 
-    # Container Configuration (Exegol pentesting container)
+    # Container Configuration
     CONTAINER_WORKSPACE_BASE: str = "/workspace"
-    DEFAULT_CONTAINER_NAME: str = "exegol-aida"
+    DEFAULT_CONTAINER_NAME: str = "aida-pentest"
+    # Comma-separated list of accepted container name prefixes.
+    # Both aida- (new) and exegol- (legacy) are accepted for backward compat.
+    CONTAINER_PREFIX_FILTER: str = "aida-,exegol-"
     COMMAND_TIMEOUT: int = 300  # seconds (5 minutes default)
 
     # Logging

--- a/backend/mcp/modules/mcp_classes.py
+++ b/backend/mcp/modules/mcp_classes.py
@@ -35,7 +35,7 @@ class AidaMCPService:
 
         # Docker/Container management
         self.current_container: Optional[str] = None
-        self.claude_container_name: str = "exegol-aida"  # Default Exegol container for AIDA
+        self.claude_container_name: str = os.getenv("DEFAULT_CONTAINER_NAME", "aida-pentest")
         self.containers_cache: List[Dict[str, Any]] = []
         self.cache_timestamp: float = 0
         self.cache_ttl: int = 30

--- a/backend/mcp/modules/mcp_handlers.py
+++ b/backend/mcp/modules/mcp_handlers.py
@@ -1341,7 +1341,7 @@ async def _handle_scan(arguments: dict, mcp_service) -> List[TextContent]:
     threads = arguments.get("threads", 10)
     extra_flags = arguments.get("extra_flags", "")
     
-    # Wordlist mapping (corrected paths for Exegol)
+    # Wordlist mapping
     WORDLISTS = {
         "common": "/usr/share/dirb/wordlists/common.txt",
         "medium": "/usr/share/dirbuster/directory-list-2.3-medium.txt",

--- a/backend/mcp/modules/mcp_tools.py
+++ b/backend/mcp/modules/mcp_tools.py
@@ -285,7 +285,7 @@ def get_tool_definitions() -> List[Tool]:
 
         Tool(
             name="execute",
-            description="Execute a command in Exegol",
+            description="Execute a command in the active pentesting container",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -305,7 +305,7 @@ def get_tool_definitions() -> List[Tool]:
         Tool(
             name="python_exec",
             description=(
-                "Execute Python code directly in the Exegol container without escaping issues. "
+                "Execute Python code directly in the active pentesting container"
                 "Pass multi-line Python as a plain string — no heredoc, no backslash hell, no quoting errors. "
                 "Use this instead of execute() for any Python script. "
                 "Supports {{PLACEHOLDER}} credential substitution in the code."
@@ -329,7 +329,7 @@ def get_tool_definitions() -> List[Tool]:
         Tool(
             name="http_request",
             description=(
-                "Make HTTP requests from inside Exegol — no curl escaping hell. "
+                "Make HTTP requests from inside the active pentesting container — no curl escaping hell. "
                 "Pass structured params (method, headers, json body, cookies, auth, proxy). "
                 "Execution stays inside the container (network isolation, VPN access). "
                 "Use proxy='http://127.0.0.1:8080' to route through Burp Suite. "

--- a/backend/services/container_service.py
+++ b/backend/services/container_service.py
@@ -144,8 +144,11 @@ class ContainerService:
                             container_name = container_data.get("Names", "unknown").lstrip('/')
                             image = container_data.get("Image", "")
 
-                            # Only include containers whose name starts with "exegol-"
-                            if container_name.lower().startswith("exegol-"):
+                            # Accept containers matching any configured prefix (aida-, exegol-, ...)
+                            allowed_prefixes = tuple(
+                                p.strip() for p in settings.CONTAINER_PREFIX_FILTER.split(",") if p.strip()
+                            )
+                            if container_name.lower().startswith(allowed_prefixes):
                                 containers.append({
                                     "name": container_name,
                                     "image": image,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,9 +31,9 @@ services:
     env_file:
       - backend/.env
     environment:
-      # Override database host to use Docker service name
-      POSTGRES_HOST: postgres
-      DATABASE_URL: postgresql://${POSTGRES_USER:-aida}:${POSTGRES_PASSWORD:-aida}@postgres:5432/${POSTGRES_DB:-aida_assessments}
+      # DB_HOST is set by switch-db.sh in root .env (default: postgres)
+      POSTGRES_HOST: ${DB_HOST:-postgres}
+      POSTGRES_DB: ${DB_NAME:-aida_assessments}
     ports:
       - "8000:8000"
     volumes:
@@ -86,6 +86,25 @@ services:
       timeout: 10s
       retries: 3
       start_period: 40s
+
+  # AIDA Pentest Container
+  # Lightweight execution environment for AI-driven assessments.
+  # The backend connects to this container via Docker socket (docker exec).
+  aida-pentest:
+    build:
+      context: ./pentest
+      dockerfile: Dockerfile
+    container_name: aida-pentest
+    tty: true
+    stdin_open: true
+    volumes:
+      # Workspace bind mount — same /workspace path as Exegol.
+      # workspace_service.py discovers this path via docker inspect, so the
+      # host path resolution in aida.py continues to work without changes.
+      - ${HOME}/.aida/workspaces:/workspace
+    networks:
+      - aida-network
+    restart: unless-stopped
 
 networks:
   aida-network:

--- a/pentest/.dockerignore
+++ b/pentest/.dockerignore
@@ -1,0 +1,7 @@
+**/__pycache__
+*.pyc
+*.pyo
+*.pyd
+.git
+.gitignore
+*.md

--- a/pentest/Dockerfile
+++ b/pentest/Dockerfile
@@ -1,0 +1,136 @@
+# =============================================================================
+# AIDA Pentest Container
+# A lightweight pentesting environment built for AIDA.
+# Same tool paths as Exegol (/usr/share/...) for zero code changes in AIDA.
+#
+# Multi-stage build:
+#   Stage 1 (gobuilder) — compiles Go tools using the official Go 1.24 image.
+#   Stage 2 (final)     — Ubuntu 22.04 with only the compiled binaries copied in.
+#   Result: no Go runtime in the final image, no version conflicts.
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Stage 1 — Build Go-based pentest tools
+# Uses the official Go 1.24 image which supports all current tool versions
+# (gobuster v3.8+ requires Go 1.24 for the `tool` directive in go.mod).
+# Binaries end up in /go/bin/ and are copied to the final stage.
+# -----------------------------------------------------------------------------
+FROM golang:1.24-bookworm AS gobuilder
+
+# Allow Go to auto-download a newer toolchain if a module requires it
+# (e.g. gobuster v3.8.2 requires Go 1.25)
+ENV GOTOOLCHAIN=auto
+
+RUN go install github.com/OJ/gobuster/v3@latest && \
+    go install github.com/ffuf/ffuf/v2@latest && \
+    go install -v github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest && \
+    go install -v github.com/projectdiscovery/dnsx/cmd/dnsx@latest
+
+
+# -----------------------------------------------------------------------------
+# Stage 2 — Final image
+# -----------------------------------------------------------------------------
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LANG=C.UTF-8
+
+# -----------------------------------------------------------------------------
+# 1. Core system + apt-installable pentest tools
+# -----------------------------------------------------------------------------
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    # System essentials
+    curl wget git unzip jq tree ca-certificates gnupg \
+    # Shell / text utils
+    netcat-openbsd socat less file xxd \
+    # Python
+    python3 python3-pip python3-venv \
+    # Network / recon
+    nmap dnsutils whois iputils-ping traceroute \
+    # Web testing
+    nikto dirb whatweb \
+    # Exploitation / brute-force
+    sqlmap hydra john hashcat \
+    # Crypto / certs
+    openssl \
+    && rm -rf /var/lib/apt/lists/*
+
+# -----------------------------------------------------------------------------
+# 2. Go-based tools — copied from builder stage (no Go runtime in final image)
+# -----------------------------------------------------------------------------
+COPY --from=gobuilder /go/bin/gobuster  /usr/local/bin/gobuster
+COPY --from=gobuilder /go/bin/ffuf      /usr/local/bin/ffuf
+COPY --from=gobuilder /go/bin/subfinder /usr/local/bin/subfinder
+COPY --from=gobuilder /go/bin/dnsx      /usr/local/bin/dnsx
+
+# -----------------------------------------------------------------------------
+# 3. Python pentesting libraries
+# -----------------------------------------------------------------------------
+RUN pip3 install --no-cache-dir \
+    requests \
+    urllib3 \
+    impacket \
+    scapy \
+    pwntools \
+    paramiko \
+    dnspython \
+    beautifulsoup4 \
+    lxml \
+    httpx \
+    boto3 \
+    PyJWT \
+    cryptography
+
+# -----------------------------------------------------------------------------
+# 4. Wordlists — same paths as Exegol so mcp_handlers.py needs zero changes
+# -----------------------------------------------------------------------------
+
+# dirb wordlists are already at /usr/share/dirb/wordlists/ from the apt install above.
+
+# All other wordlists come from SecLists via git sparse-checkout.
+# --filter=blob:none  → clone tree only (~5 MB), no file content yet
+# --sparse / --no-cone → let us request individual files by path
+# Only the 6 files actually referenced in mcp_handlers.py are fetched.
+#
+# Verified paths from SecLists master as of 2025:
+#   - DirBuster lists live flat in Web-Content/ with a DirBuster-2007_ prefix
+#   - raft-medium-directories.txt (mcp_handlers uses "directories", not "words")
+#   - Passwords dir is Common-Credentials (not CommonCredentials) — not needed by AIDA
+RUN git clone --depth=1 --filter=blob:none --sparse \
+        https://github.com/danielmiessler/SecLists.git /tmp/seclists && \
+    cd /tmp/seclists && \
+    git sparse-checkout init --no-cone && \
+    git sparse-checkout set \
+        "Discovery/Web-Content/raft-small-words.txt" \
+        "Discovery/Web-Content/raft-medium-directories.txt" \
+        "Discovery/Web-Content/DirBuster-2007_directory-list-2.3-medium.txt" \
+        "Discovery/Web-Content/DirBuster-2007_directory-list-2.3-big.txt" \
+        "Discovery/DNS/subdomains-top1million-5000.txt" \
+        "Discovery/DNS/subdomains-top1million-20000.txt" && \
+    # --- /usr/share/seclists/ — exact paths used by mcp_handlers.py ---
+    mkdir -p \
+        /usr/share/seclists/Discovery/Web-Content \
+        /usr/share/seclists/Discovery/DNS && \
+    cp "Discovery/Web-Content/raft-small-words.txt"       /usr/share/seclists/Discovery/Web-Content/ && \
+    cp "Discovery/Web-Content/raft-medium-directories.txt" /usr/share/seclists/Discovery/Web-Content/ && \
+    cp "Discovery/DNS/subdomains-top1million-5000.txt"     /usr/share/seclists/Discovery/DNS/ && \
+    cp "Discovery/DNS/subdomains-top1million-20000.txt"    /usr/share/seclists/Discovery/DNS/ && \
+    # --- /usr/share/dirbuster/ — DirBuster files renamed to expected paths ---
+    mkdir -p /usr/share/dirbuster && \
+    cp "Discovery/Web-Content/DirBuster-2007_directory-list-2.3-medium.txt" \
+        /usr/share/dirbuster/directory-list-2.3-medium.txt && \
+    cp "Discovery/Web-Content/DirBuster-2007_directory-list-2.3-big.txt" \
+        /usr/share/dirbuster/directory-list-2.3-big.txt && \
+    # Cleanup
+    cd / && rm -rf /tmp/seclists
+
+# -----------------------------------------------------------------------------
+# 5. Workspace directory (bind-mounted at runtime by docker-compose)
+# -----------------------------------------------------------------------------
+RUN mkdir -p /workspace
+WORKDIR /workspace
+
+# -----------------------------------------------------------------------------
+# 6. Keep container alive — AIDA connects via docker exec
+# -----------------------------------------------------------------------------
+CMD ["tail", "-f", "/dev/null"]

--- a/start.sh
+++ b/start.sh
@@ -137,6 +137,47 @@ if [[ ! -f frontend/.env ]]; then
 fi
 
 # ==============================================================================
+# FIRST-RUN: CONTAINER MODE SELECTION
+# ==============================================================================
+
+CONTAINER_PREFS_FILE="$SCRIPT_DIR/.aida/container-preference"
+mkdir -p "$SCRIPT_DIR/.aida"
+
+if [[ ! -f "$CONTAINER_PREFS_FILE" ]]; then
+    section "First-Run Setup"
+    echo ""
+    echo "  AIDA needs a pentesting container to run security tools."
+    echo ""
+    echo "  [1] aida-pentest  (Recommended)"
+    echo "      Built-in, managed by AIDA — starts automatically with ./start.sh"
+    echo "      Size: ~2 GB |  Tools: nmap, ffuf, gobuster, sqlmap, nikto..."
+    echo ""
+    echo "  [2] Exegol"
+    echo "      Third-party, requires separate install: https://docs.exegol.com"
+    echo "      Size: ~20-40 GB  |  Tools: ~400+ security tools"
+    echo ""
+    echo "  You can always switch containers in Settings."
+    echo ""
+    read -p "  Your choice [1/2, default=1]: " -n 1 -r CONTAINER_CHOICE
+    echo ""
+    echo ""
+
+    if [[ "$CONTAINER_CHOICE" == "2" ]]; then
+        echo "exegol" > "$CONTAINER_PREFS_FILE"
+        warn "Exegol mode selected."
+        warn "Make sure Exegol is installed and a container is running before using AIDA:"
+        warn "  Install: https://docs.exegol.com/first-install"
+        warn "  Start:   exegol start aida"
+        echo ""
+    else
+        echo "aida-pentest" > "$CONTAINER_PREFS_FILE"
+        log "aida-pentest selected — the built-in container will start automatically."
+    fi
+fi
+
+CONTAINER_MODE=$(cat "$CONTAINER_PREFS_FILE" 2>/dev/null || echo "aida-pentest")
+
+# ==============================================================================
 # PYTHON ENVIRONMENTS (Only if missing)
 # ==============================================================================
 
@@ -205,10 +246,21 @@ fi
 # Check if images exist
 BACKEND_IMAGE=$(docker images -q aida-backend 2>/dev/null)
 FRONTEND_IMAGE=$(docker images -q aida-frontend 2>/dev/null)
+PENTEST_IMAGE=$(docker images -q aida-aida-pentest 2>/dev/null)
 
-if [[ -z "$BACKEND_IMAGE" ]] || [[ -z "$FRONTEND_IMAGE" ]] || [[ "$FORCE_BUILD" == "true" ]]; then
-    log "Building Docker images..."
-    docker compose build --quiet
+BUILD_NEEDED=false
+[[ -z "$BACKEND_IMAGE" || -z "$FRONTEND_IMAGE" ]] && BUILD_NEEDED=true
+[[ "$CONTAINER_MODE" == "aida-pentest" && -z "$PENTEST_IMAGE" ]] && BUILD_NEEDED=true
+[[ "$FORCE_BUILD" == "true" ]] && BUILD_NEEDED=true
+
+if [[ "$BUILD_NEEDED" == "true" ]]; then
+    if [[ "$CONTAINER_MODE" == "aida-pentest" ]]; then
+        log "Building Docker images (first build of aida-pentest may take a few minutes)..."
+        docker compose build --quiet
+    else
+        log "Building Docker images..."
+        docker compose build --quiet backend frontend
+    fi
     log "Images built"
 else
     log "Docker images already exist (use --build to rebuild)"
@@ -226,11 +278,19 @@ if [[ "$RUNNING_CONTAINERS" -ge 3 ]]; then
     log "Containers already running"
 elif [[ "$STOPPED_CONTAINERS" -gt 0 ]]; then
     log "Starting existing containers..."
-    docker compose start 2>/dev/null
+    if [[ "$CONTAINER_MODE" == "aida-pentest" ]]; then
+        docker compose start 2>/dev/null
+    else
+        docker compose start postgres backend frontend 2>/dev/null
+    fi
 else
     log "Creating and starting containers..."
     # Suppress volume warning (cosmetic - data is preserved)
-    docker compose up -d 2>&1 | grep -v "already exists but was created for project" || true
+    if [[ "$CONTAINER_MODE" == "aida-pentest" ]]; then
+        docker compose up -d 2>&1 | grep -v "already exists but was created for project" || true
+    else
+        docker compose up -d postgres backend frontend 2>&1 | grep -v "already exists but was created for project" || true
+    fi
 fi
 
 # ==============================================================================
@@ -271,15 +331,27 @@ if [[ -f "$SCRIPT_DIR/tools/folder_opener.py" ]]; then
 fi
 
 # ==============================================================================
-# EXEGOL CHECK
+# PENTEST CONTAINER STATUS
 # ==============================================================================
 
-EXEGOL_RUNNING=$(docker ps --format "{{.Names}}" 2>/dev/null | grep -i "^exegol-" || true)
-if [[ -z "$EXEGOL_RUNNING" ]]; then
-    echo ""
-    warn "No Exegol container running!"
-    warn "AIDA needs Exegol for pentesting tools."
-    warn "Start one with: exegol start <name>"
+if [[ "$CONTAINER_MODE" == "exegol" ]]; then
+    EXEGOL_RUNNING=$(docker ps --format "{{.Names}}" 2>/dev/null | grep -i "^exegol-" || true)
+    if [[ -z "$EXEGOL_RUNNING" ]]; then
+        echo ""
+        warn "No Exegol container running!"
+        warn "Start one with:      exegol start <name>"
+        warn "Switch to built-in:  rm .aida/container-preference && ./start.sh"
+    else
+        log "Exegol container: $EXEGOL_RUNNING"
+    fi
+else
+    PENTEST_RUNNING=$(docker ps --format "{{.Names}}" 2>/dev/null | grep "^aida-pentest$" || true)
+    if [[ -z "$PENTEST_RUNNING" ]]; then
+        warn "aida-pentest not running — starting..."
+        docker compose up -d aida-pentest 2>&1 | grep -v "already" || true
+    else
+        log "Pentesting container: aida-pentest"
+    fi
 fi
 
 # ==============================================================================


### PR DESCRIPTION
## Summary

- **New `pentest/Dockerfile`**: multi-stage build (golang builder + ubuntu:22.04) with nmap, nikto, sqlmap, dirb, hydra, ffuf, gobuster, subfinder, dnsx, impacket, scapy, pwntools, paramiko and all Python pentesting libs. Wordlists fetched via sparse-checkout (only the 6 files referenced by `mcp_handlers.py`).
- **docker-compose.yml**: new `aida-pentest` service with workspace bind-mount at `~/.aida/workspaces:/workspace`.
- **Backend config**: `DEFAULT_CONTAINER_NAME=aida-pentest`, `CONTAINER_PREFIX_FILTER=aida-,exegol-` for backward compatibility with existing Exegol containers.
- **Container service**: prefix filter is now configurable instead of hardcoded `exegol-`.
- **Docs**: updated README, INSTALLATION, and PrePrompt to reflect the new container.