### PR TITLE
feat: UI-initiated headless Claude agent runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,48 @@ Here's Claude Desktop as an example:
 
 ---
 
+## UI-Initiated Scans (headless agent)
+
+In addition to the CLI flow above, you can kick off a fully headless Claude
+session directly from the assessment page. The agent runs inside the backend
+container, uses the same MCP server, and streams every `thinking` / `tool_use`
+/ `tool_result` event into a live transcript in the UI. You can stop the run
+at any time, inspect past runs, and pick a specific model (Sonnet 4.6 / Opus
+4.7 / Haiku 4.5).
+
+This path auth'es against your **Max subscription** via an OAuth token — no
+API key required, no extra per-token billing.
+
+**One-time setup:**
+
+1. On the host (not inside the container) generate a token:
+   ```bash
+   claude setup-token
+   ```
+   It'll open a browser, ask you to sign in, and print a long `sk-ant-oat01-…`
+   string.
+
+2. Paste it into `backend/.env`:
+   ```ini
+   CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-...
+   ```
+
+3. (Re)start the stack:
+   ```bash
+   ./start.sh
+   ```
+
+Then open any assessment → **AI Scans** panel → *New scan* → describe the
+goal and hit *Start*. Leave the field blank and you get a scripted mock run
+— handy for demoing the panel without credentials.
+
+> Behind the scenes the agent runs as a non-root user inside the container
+> (claude CLI refuses `--dangerously-skip-permissions` under root) and talks
+> to the `aida-pentest` container through the same docker socket proxy the
+> rest of the backend uses.
+
+---
+
 ## Works With Any AI
 
 AIDA uses the **Model Context Protocol (MCP)** - an open standard. If your AI client supports MCP, it works with AIDA.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -26,6 +26,37 @@ RUN install -m 0755 -d /etc/apt/keyrings && \
     apt-get install -y --no-install-recommends docker-ce-cli && \
     rm -rf /var/lib/apt/lists/*
 
+# Install Node.js 20 + Claude Code CLI — powers UI-initiated headless agent
+# runs. Auth comes from CLAUDE_CODE_OAUTH_TOKEN env (generated once on the
+# host via `claude setup-token`) so the Max subscription works from inside
+# the container without access to the macOS Keychain.
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    apt-get install -y --no-install-recommends nodejs util-linux && \
+    npm install -g @anthropic-ai/claude-code && \
+    npm cache clean --force && \
+    rm -rf /var/lib/apt/lists/*
+
+# Claude CLI refuses `--dangerously-skip-permissions` (our bypassPermissions
+# mode) when invoked as root. uvicorn itself still needs root for the volume
+# mounts, so we only drop privileges for the `claude` subprocess via a thin
+# wrapper that re-execs under a dedicated non-root user. setpriv is used
+# (not runuser) because runuser runs PAM session setup, which swallows the
+# stdin/stdout pipes the SDK needs for its JSON protocol. HOME must be set
+# explicitly so claude can write its session state under the new uid.
+RUN useradd -u 1000 -m -s /bin/bash aida && \
+    install -d -o aida -g aida /home/aida/.claude && \
+    CLAUDE_REAL="$(readlink -f /usr/bin/claude)" && \
+    mv "$CLAUDE_REAL" "${CLAUDE_REAL}.real" && \
+    { \
+      echo '#!/bin/sh'; \
+      echo 'if [ "$(id -u)" = "0" ]; then'; \
+      echo "  exec setpriv --reuid=1000 --regid=1000 --init-groups env HOME=/home/aida ${CLAUDE_REAL}.real \"\$@\""; \
+      echo 'else'; \
+      echo "  exec ${CLAUDE_REAL}.real \"\$@\""; \
+      echo 'fi'; \
+    } > "$CLAUDE_REAL" && \
+    chmod +x "$CLAUDE_REAL"
+
 # Set working directory
 WORKDIR /app
 

--- a/backend/agent/__init__.py
+++ b/backend/agent/__init__.py
@@ -1,0 +1,10 @@
+"""
+Headless Claude agent orchestration for UI-initiated scans.
+
+This package intentionally does not touch the CLI workflow (python3 aida.py);
+the CLI path remains a parallel, independent mechanism.
+"""
+from .runner import AgentRunner, agent_runner
+from . import _sdk_compat  # noqa: F401 — monkey-patch side-effect
+
+__all__ = ["AgentRunner", "agent_runner"]

--- a/backend/agent/_sdk_compat.py
+++ b/backend/agent/_sdk_compat.py
@@ -1,0 +1,54 @@
+"""
+Forward-compat shim for claude-code-sdk.
+
+The SDK's `parse_message` raises `MessageParseError` on unknown message types,
+which kills the whole `async for message in query(...)` iterator. Anthropic
+ships new message kinds (e.g. `rate_limit_event`) before the SDK catches up,
+so we replace the raise with a `SystemMessage` fallback. Our session handler
+already renders SystemMessages of any subtype, so the run keeps streaming.
+"""
+from __future__ import annotations
+
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+def _install() -> None:
+    try:
+        from claude_code_sdk._internal import message_parser as mp
+        from claude_code_sdk._errors import MessageParseError
+        from claude_code_sdk.types import SystemMessage
+    except ImportError:
+        # SDK not installed (first boot / tests). Nothing to patch.
+        return
+
+    original_parse_message = mp.parse_message
+
+    def safe_parse_message(data):
+        try:
+            return original_parse_message(data)
+        except MessageParseError as exc:
+            msg_type = data.get("type") if isinstance(data, dict) else None
+            logger.warning(
+                "Unknown SDK message type — surfacing as SystemMessage",
+                message_type=msg_type,
+                error=str(exc),
+            )
+            return SystemMessage(
+                subtype=str(msg_type) if msg_type else "unknown",
+                data=data if isinstance(data, dict) else {"raw": repr(data)},
+            )
+
+    mp.parse_message = safe_parse_message
+
+    # client.py did `from .message_parser import parse_message` at import
+    # time, so it holds its own reference we need to rebind separately.
+    try:
+        from claude_code_sdk._internal import client as _client
+        _client.parse_message = safe_parse_message
+    except ImportError:
+        pass
+
+
+_install()

--- a/backend/agent/mcp_config.py
+++ b/backend/agent/mcp_config.py
@@ -1,0 +1,47 @@
+"""
+Build the MCP stdio-server config that the headless Claude process uses.
+
+Equivalent to the `generate_mcp_config` in aida.py, but tailored for running
+inside the backend container:
+    - `python3` is already on PATH (no venv detection needed)
+    - working directory is /app, so PYTHONPATH=/app points at the backend code
+    - the MCP server file is shipped as part of the image at /app/mcp/...
+"""
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any, Dict, Optional
+
+from config import settings
+
+
+# Inside the backend container the MCP server lives next to the other modules.
+MCP_SERVER_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "mcp",
+    "aida_mcp_server.py",
+)
+BACKEND_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def build_mcp_servers(aida_token: Optional[str]) -> Dict[str, Any]:
+    """Return the `mcp_servers` dict expected by claude-code-sdk.
+
+    `aida_token` must be a valid JWT so the MCP server can call the protected
+    backend API on behalf of the user who started the run.
+    """
+    return {
+        "aida-mcp": {
+            "type": "stdio",
+            "command": sys.executable,
+            "args": [MCP_SERVER_PATH],
+            "env": {
+                # MCP server imports from the backend package; anchor the path.
+                "PYTHONPATH": BACKEND_DIR,
+                "DATABASE_URL": str(settings.DATABASE_URL),
+                "AIDA_TOKEN": aida_token or "",
+                "BACKEND_API_URL": settings.BACKEND_API_URL,
+            },
+        }
+    }

--- a/backend/agent/preprompt.py
+++ b/backend/agent/preprompt.py
@@ -1,0 +1,83 @@
+"""
+Load and enrich the system prompt for a headless agent run.
+
+Mirrors the logic in aida.py:627-705: read Docs/PrePrompt.txt verbatim and
+append a short block describing the assessment that the run is tied to.
+"""
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from models import Assessment
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+# Inside the backend container the repo root is /app (WORKDIR); Docs/ is
+# copied as part of the image build. When running under uvicorn --reload the
+# mount is ./backend:/app, so Docs is not under /app — fall back to the
+# sibling directory of /app.
+_CANDIDATE_PATHS = (
+    "/app/Docs/PrePrompt.txt",
+    "/Docs/PrePrompt.txt",
+    os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "..", "Docs", "PrePrompt.txt")
+    ),
+)
+
+
+def _load_preprompt() -> str:
+    for path in _CANDIDATE_PATHS:
+        if os.path.exists(path):
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    return f.read()
+            except OSError as exc:
+                logger.warning("Failed to read preprompt", path=path, error=str(exc))
+    logger.warning("PrePrompt.txt not found; using empty system prompt")
+    return ""
+
+
+def build_system_prompt(assessment: Assessment, goal: str) -> str:
+    """Return the full system prompt for an agent run."""
+    base = _load_preprompt()
+    context = _assessment_context_block(assessment, goal)
+    if not base.endswith("\n"):
+        base += "\n"
+    return base + context
+
+
+def _assessment_context_block(assessment: Assessment, goal: str) -> str:
+    """Append the assessment-specific context section the model needs."""
+    target_domains = ", ".join(assessment.target_domains or []) or "—"
+    ip_scopes = ", ".join(assessment.ip_scopes or []) or "—"
+
+    return f"""
+## **Assessment Loaded**
+
+**{assessment.name}** (ID: {assessment.id}) - Container: {assessment.container_name or "—"}
+
+- Scope: {assessment.scope or "—"}
+- Target domains: {target_domains}
+- IP scopes: {ip_scopes}
+- Environment: {assessment.environment or "—"}
+- Category: {assessment.category or "—"}
+
+## **User Goal**
+
+{goal}
+
+The assessment workspace is ready. Use your standard tools to work with files and execute commands. Persist findings via the AIDA MCP tools.
+"""
+
+
+def get_workspace_cwd(assessment: Optional[Assessment]) -> Optional[str]:
+    """Best-effort working directory for the headless `claude` process.
+
+    The backend container doesn't have workspace bind-mounts, so the CLI
+    simply runs with cwd=/app. Hook kept as a seam for when we wire up a
+    per-assessment workspace mount.
+    """
+    return None

--- a/backend/agent/runner.py
+++ b/backend/agent/runner.py
@@ -1,0 +1,75 @@
+"""
+AgentRunner — process-wide registry of in-flight AgentSession tasks.
+
+Owns the mapping {run_id: asyncio.Task} so the API layer can start and
+cancel runs without needing to know anything about the session mechanics.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Dict, Optional
+
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class AgentRunner:
+    """Singleton manager for concurrent agent sessions."""
+
+    def __init__(self) -> None:
+        self._tasks: Dict[int, asyncio.Task] = {}
+        self._lock = asyncio.Lock()
+
+    async def start(
+        self,
+        run_id: int,
+        assessment_id: int,
+        goal: str,
+        permission_mode: Optional[str],
+        model: Optional[str],
+    ) -> None:
+        """Schedule a new AgentSession for this run_id."""
+        # Import inside the function to avoid a circular import at module
+        # load time (session imports ws events which import from websocket
+        # package that may not be ready when agent package is first loaded).
+        from .session import AgentSession
+
+        async with self._lock:
+            if run_id in self._tasks and not self._tasks[run_id].done():
+                raise RuntimeError(f"Run {run_id} is already running")
+
+            session = AgentSession(
+                run_id=run_id,
+                assessment_id=assessment_id,
+                goal=goal,
+                permission_mode=permission_mode,
+                model=model,
+            )
+            task = asyncio.create_task(session.run(), name=f"agent-run-{run_id}")
+            self._tasks[run_id] = task
+
+            # Cleanup reference when the task ends so the dict does not grow
+            # without bound over the lifetime of the process.
+            task.add_done_callback(lambda _t, rid=run_id: self._tasks.pop(rid, None))
+
+        logger.info("Agent run scheduled", run_id=run_id, assessment_id=assessment_id)
+
+    async def stop(self, run_id: int) -> bool:
+        """Cancel the task for run_id. Returns True if a task was cancelled."""
+        async with self._lock:
+            task = self._tasks.get(run_id)
+            if task is None or task.done():
+                return False
+            task.cancel()
+
+        logger.info("Agent run cancel requested", run_id=run_id)
+        return True
+
+    def is_running(self, run_id: int) -> bool:
+        task = self._tasks.get(run_id)
+        return task is not None and not task.done()
+
+
+# Process-wide instance used by the API layer
+agent_runner = AgentRunner()

--- a/backend/agent/session.py
+++ b/backend/agent/session.py
@@ -1,0 +1,430 @@
+"""
+AgentSession — runs one headless Claude session end-to-end.
+
+Two execution paths share the same persistence/WS plumbing below:
+    * Real: spawns `claude` via claude-code-sdk when CLAUDE_CODE_OAUTH_TOKEN
+      (or ANTHROPIC_API_KEY) is set in the backend env. Uses the AIDA MCP
+      server for tool access and the same Docs/PrePrompt.txt system prompt
+      the CLI path loads.
+    * Mock: scripted events mimicking the real SDK shape. Kept around so the
+      panel is demoable without credentials, and so plumbing regressions
+      show up deterministically.
+
+The branch is picked at runtime in `_run_session()` — nothing about the
+DB / WS layer differs between the two.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from datetime import datetime, timezone
+from typing import List, Dict, Any, Optional
+
+from sqlalchemy.orm import Session
+
+from auth import create_api_token
+from database import SessionLocal
+from models import AgentRun, Assessment, User
+from schemas.agent_run import AgentRunResponse
+from utils.logger import get_logger
+from websocket.manager import manager
+from websocket.events import (
+    event_agent_run_started,
+    event_agent_run_message,
+    event_agent_run_completed,
+    event_agent_run_failed,
+    event_agent_run_stopped,
+)
+
+from .mcp_config import build_mcp_servers
+from .preprompt import build_system_prompt, get_workspace_cwd
+
+
+logger = get_logger(__name__)
+
+DEFAULT_PERMISSION_MODE = "bypassPermissions"
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def _response_dict(run: AgentRun) -> dict:
+    """Serialise an AgentRun ORM instance to the shape the UI consumes."""
+    return AgentRunResponse.model_validate(run).model_dump(mode="json")
+
+
+def _has_claude_credentials() -> bool:
+    """Real SDK path needs either an OAuth token (Max) or an API key."""
+    return bool(
+        os.getenv("CLAUDE_CODE_OAUTH_TOKEN")
+        or os.getenv("ANTHROPIC_API_KEY")
+    )
+
+
+class AgentSession:
+    """One execution of a UI-initiated scan."""
+
+    MOCK_STEP_DELAY = 1.0  # seconds between scripted mock events
+
+    def __init__(
+        self,
+        run_id: int,
+        assessment_id: int,
+        goal: str,
+        permission_mode: Optional[str],
+        model: Optional[str],
+    ) -> None:
+        self.run_id = run_id
+        self.assessment_id = assessment_id
+        self.goal = goal
+        self.permission_mode = permission_mode or DEFAULT_PERMISSION_MODE
+        self.model = model
+        self._transcript: List[Dict[str, Any]] = []
+
+    async def run(self) -> None:
+        """Main entry point scheduled as an asyncio.Task."""
+        started_at_wall = time.monotonic()
+        try:
+            await self._mark_running()
+            await self._run_session()
+            duration_ms = int((time.monotonic() - started_at_wall) * 1000)
+            await self._mark_completed(duration_ms=duration_ms)
+        except asyncio.CancelledError:
+            await self._mark_stopped()
+        except Exception as exc:
+            logger.exception("Agent session failed", run_id=self.run_id)
+            await self._mark_failed(str(exc))
+
+    async def _run_session(self) -> None:
+        if _has_claude_credentials():
+            await self._run_real_session()
+        else:
+            logger.info(
+                "CLAUDE_CODE_OAUTH_TOKEN/ANTHROPIC_API_KEY not set — "
+                "running mock session",
+                run_id=self.run_id,
+            )
+            await self._run_mock_session()
+
+    # ------------------------------------------------------------------
+    # Real SDK session
+    # ------------------------------------------------------------------
+    async def _run_real_session(self) -> None:
+        # Imported lazily so backend still starts without the SDK installed
+        # (e.g. first boot before an image rebuild).
+        from claude_code_sdk import query, ClaudeCodeOptions
+
+        assessment, aida_token = self._prepare_session_context()
+
+        options_kwargs = dict(
+            system_prompt=build_system_prompt(assessment, self.goal),
+            mcp_servers=build_mcp_servers(aida_token),
+            permission_mode=self.permission_mode,
+        )
+        if self.model:
+            options_kwargs["model"] = self.model
+        cwd = get_workspace_cwd(assessment)
+        if cwd:
+            options_kwargs["cwd"] = cwd
+
+        options = ClaudeCodeOptions(**options_kwargs)
+
+        async for message in query(prompt=self.goal, options=options):
+            await self._handle_sdk_message(message)
+
+    def _prepare_session_context(self) -> tuple[Assessment, Optional[str]]:
+        """Load the assessment row and mint a scoped MCP token."""
+        db: Session = SessionLocal()
+        try:
+            assessment = (
+                db.query(Assessment)
+                .filter(Assessment.id == self.assessment_id)
+                .first()
+            )
+            if assessment is None:
+                raise RuntimeError(
+                    f"Assessment {self.assessment_id} vanished before run start"
+                )
+
+            run = db.query(AgentRun).filter(AgentRun.id == self.run_id).first()
+            user = None
+            if run and run.user_id:
+                user = db.query(User).filter(User.id == run.user_id).first()
+
+            aida_token = None
+            if user:
+                aida_token = create_api_token(
+                    user_id=user.id, username=user.username
+                )
+
+            # Detach so the ORM instance is usable after the session closes.
+            db.expunge(assessment)
+            return assessment, aida_token
+        finally:
+            db.close()
+
+    async def _handle_sdk_message(self, message: Any) -> None:
+        """Convert an SDK message to one or more transcript events."""
+        # Use class-name sniffing so we don't hard-fail if the SDK changes
+        # its public typing surface between minor versions.
+        cls_name = type(message).__name__
+
+        if cls_name == "SystemMessage":
+            subtype = getattr(message, "subtype", None)
+            data = getattr(message, "data", {}) or {}
+            if subtype == "init":
+                await self._emit({
+                    "type": "system_init",
+                    "session_id": data.get("session_id"),
+                    "model": data.get("model") or self.model,
+                })
+            else:
+                await self._emit({
+                    "type": "system",
+                    "subtype": subtype,
+                    "data": data,
+                })
+            return
+
+        if cls_name == "AssistantMessage":
+            for block in getattr(message, "content", []) or []:
+                await self._emit_block(block, role="assistant")
+            return
+
+        if cls_name == "UserMessage":
+            # User messages in the SDK stream are synthetic — they carry
+            # tool_result blocks produced by MCP tools.
+            for block in getattr(message, "content", []) or []:
+                await self._emit_block(block, role="user")
+            return
+
+        if cls_name == "ResultMessage":
+            await self._emit({
+                "type": "result",
+                "num_turns": getattr(message, "num_turns", None),
+                "duration_ms": getattr(message, "duration_ms", None),
+                "total_cost_usd": getattr(message, "total_cost_usd", None),
+                "is_error": getattr(message, "is_error", False),
+            })
+            return
+
+        # Fallthrough — unknown message shape: surface it so we can iterate.
+        await self._emit({
+            "type": "unknown",
+            "class": cls_name,
+            "repr": repr(message)[:2000],
+        })
+
+    async def _emit_block(self, block: Any, role: str) -> None:
+        cls_name = type(block).__name__
+        if cls_name == "TextBlock":
+            text = getattr(block, "text", "") or ""
+            if text.strip():
+                await self._emit({"type": "assistant_text", "text": text})
+            return
+        if cls_name == "ThinkingBlock":
+            thinking = getattr(block, "thinking", "") or ""
+            if thinking.strip():
+                await self._emit({"type": "thinking", "text": thinking})
+            return
+        if cls_name == "ToolUseBlock":
+            await self._emit({
+                "type": "tool_use",
+                "id": getattr(block, "id", None),
+                "name": getattr(block, "name", None),
+                "input": getattr(block, "input", None),
+            })
+            return
+        if cls_name == "ToolResultBlock":
+            await self._emit({
+                "type": "tool_result",
+                "tool_use_id": getattr(block, "tool_use_id", None),
+                "content": _normalize_tool_result(getattr(block, "content", None)),
+                "is_error": bool(getattr(block, "is_error", False)),
+            })
+            return
+
+        await self._emit({
+            "type": "block",
+            "class": cls_name,
+            "role": role,
+            "repr": repr(block)[:2000],
+        })
+
+    # ------------------------------------------------------------------
+    # Mock fallback
+    # ------------------------------------------------------------------
+    async def _run_mock_session(self) -> None:
+        self.model = self.model or "mock-claude"
+        await self._emit({
+            "type": "system_init",
+            "session_id": f"mock-{self.run_id}",
+            "model": self.model,
+        })
+        await asyncio.sleep(self.MOCK_STEP_DELAY)
+
+        await self._emit({
+            "type": "assistant_text",
+            "text": (
+                f"Understood. I will work on the following goal: {self.goal}\n"
+                "Starting with reconnaissance."
+            ),
+        })
+        await asyncio.sleep(self.MOCK_STEP_DELAY)
+
+        await self._emit({
+            "type": "tool_use",
+            "name": "mcp__aida__execute_command",
+            "input": {"command": "nmap -sV -top-ports 20 example.local"},
+        })
+        await asyncio.sleep(self.MOCK_STEP_DELAY * 2)
+
+        await self._emit({
+            "type": "tool_result",
+            "content": (
+                "PORT     STATE SERVICE    VERSION\n"
+                "22/tcp   open  ssh        OpenSSH 8.4\n"
+                "80/tcp   open  http       nginx 1.24\n"
+                "443/tcp  open  https      nginx 1.24\n"
+            ),
+        })
+        await asyncio.sleep(self.MOCK_STEP_DELAY)
+
+        await self._emit({
+            "type": "assistant_text",
+            "text": (
+                "Found SSH + nginx on the target. This is a mock run — set "
+                "CLAUDE_CODE_OAUTH_TOKEN in backend/.env to run against the "
+                "real model."
+            ),
+        })
+        await asyncio.sleep(self.MOCK_STEP_DELAY)
+
+        await self._emit({
+            "type": "result",
+            "num_turns": 2,
+            "total_cost_usd": 0.0,
+            "duration_ms": int(self.MOCK_STEP_DELAY * 5 * 1000),
+        })
+
+    # ------------------------------------------------------------------
+    # Event emission and persistence
+    # ------------------------------------------------------------------
+    async def _emit(self, message: Dict[str, Any]) -> None:
+        message = {**message, "ts": _utcnow().isoformat()}
+        self._transcript.append(message)
+        await manager.broadcast(
+            event_agent_run_message(self.assessment_id, self.run_id, message),
+            assessment_id=self.assessment_id,
+        )
+
+    # ------------------------------------------------------------------
+    # State transitions (DB + WS)
+    # ------------------------------------------------------------------
+    async def _mark_running(self) -> None:
+        db: Session = SessionLocal()
+        try:
+            run = db.query(AgentRun).filter(AgentRun.id == self.run_id).first()
+            if run is None:
+                raise RuntimeError(f"AgentRun {self.run_id} vanished before start")
+            run.status = "running"
+            run.started_at = _utcnow()
+            if self.model:
+                run.model = self.model
+            db.commit()
+            db.refresh(run)
+            payload = _response_dict(run)
+        finally:
+            db.close()
+
+        await manager.broadcast(
+            event_agent_run_started(self.assessment_id, payload),
+            assessment_id=self.assessment_id,
+        )
+
+    async def _mark_completed(self, duration_ms: int) -> None:
+        result_meta = next(
+            (m for m in reversed(self._transcript) if m.get("type") == "result"),
+            None,
+        )
+
+        db: Session = SessionLocal()
+        try:
+            run = db.query(AgentRun).filter(AgentRun.id == self.run_id).first()
+            if run is None:
+                return
+            run.status = "completed"
+            run.ended_at = _utcnow()
+            run.transcript = self._transcript
+            run.duration_ms = duration_ms
+            if result_meta:
+                run.num_turns = result_meta.get("num_turns")
+                cost = result_meta.get("total_cost_usd")
+                if cost is not None:
+                    run.cost_usd = float(cost)
+            db.commit()
+            db.refresh(run)
+            payload = _response_dict(run)
+        finally:
+            db.close()
+
+        await manager.broadcast(
+            event_agent_run_completed(self.assessment_id, payload),
+            assessment_id=self.assessment_id,
+        )
+
+    async def _mark_failed(self, error: str) -> None:
+        db: Session = SessionLocal()
+        try:
+            run = db.query(AgentRun).filter(AgentRun.id == self.run_id).first()
+            if run is None:
+                return
+            run.status = "failed"
+            run.ended_at = _utcnow()
+            run.error = error
+            run.transcript = self._transcript or None
+            db.commit()
+        finally:
+            db.close()
+
+        await manager.broadcast(
+            event_agent_run_failed(self.assessment_id, self.run_id, error),
+            assessment_id=self.assessment_id,
+        )
+
+    async def _mark_stopped(self) -> None:
+        db: Session = SessionLocal()
+        try:
+            run = db.query(AgentRun).filter(AgentRun.id == self.run_id).first()
+            if run is None:
+                return
+            run.status = "stopped"
+            run.ended_at = _utcnow()
+            run.transcript = self._transcript or None
+            db.commit()
+        finally:
+            db.close()
+
+        await manager.broadcast(
+            event_agent_run_stopped(self.assessment_id, self.run_id),
+            assessment_id=self.assessment_id,
+        )
+
+
+def _normalize_tool_result(content: Any) -> Any:
+    """Flatten SDK tool-result content blocks to plain strings/dicts."""
+    if content is None:
+        return None
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: List[Any] = []
+        for item in content:
+            if isinstance(item, dict):
+                parts.append(item.get("text") or item)
+            else:
+                parts.append(repr(item))
+        return "\n".join(p if isinstance(p, str) else repr(p) for p in parts)
+    return repr(content)

--- a/backend/alembic/versions/003_agent_runs.py
+++ b/backend/alembic/versions/003_agent_runs.py
@@ -1,0 +1,67 @@
+"""Add agent_runs table for UI-initiated Claude sessions
+
+Revision ID: 003_agent_runs
+Revises: 002_user_roles
+Create Date: 2026-04-17
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = '003_agent_runs'
+down_revision: Union[str, None] = '002_user_roles'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'agent_runs',
+        sa.Column('id', sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column(
+            'assessment_id',
+            sa.Integer(),
+            sa.ForeignKey('assessments.id', ondelete='CASCADE'),
+            nullable=False,
+        ),
+        sa.Column(
+            'user_id',
+            sa.Integer(),
+            sa.ForeignKey('users.id', ondelete='SET NULL'),
+            nullable=True,
+        ),
+        sa.Column('goal', sa.Text(), nullable=False),
+        sa.Column(
+            'status',
+            sa.String(20),
+            nullable=False,
+            server_default='queued',
+        ),
+        sa.Column('permission_mode', sa.String(32), nullable=True),
+        sa.Column('model', sa.String(64), nullable=True),
+        sa.Column('error', sa.Text(), nullable=True),
+        sa.Column('num_turns', sa.Integer(), nullable=True),
+        sa.Column('cost_usd', sa.Float(), nullable=True),
+        sa.Column('duration_ms', sa.Integer(), nullable=True),
+        sa.Column('transcript', postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column('created_at', sa.TIMESTAMP(), server_default=sa.text('now()')),
+        sa.Column('started_at', sa.TIMESTAMP(), nullable=True),
+        sa.Column('ended_at', sa.TIMESTAMP(), nullable=True),
+    )
+    op.create_index(
+        'ix_agent_runs_assessment_id', 'agent_runs', ['assessment_id']
+    )
+    op.create_index('ix_agent_runs_user_id', 'agent_runs', ['user_id'])
+    op.create_index('ix_agent_runs_status', 'agent_runs', ['status'])
+    op.create_index('ix_agent_runs_created_at', 'agent_runs', ['created_at'])
+
+
+def downgrade() -> None:
+    op.drop_index('ix_agent_runs_created_at', table_name='agent_runs')
+    op.drop_index('ix_agent_runs_status', table_name='agent_runs')
+    op.drop_index('ix_agent_runs_user_id', table_name='agent_runs')
+    op.drop_index('ix_agent_runs_assessment_id', table_name='agent_runs')
+    op.drop_table('agent_runs')

--- a/backend/api/agent.py
+++ b/backend/api/agent.py
@@ -1,0 +1,105 @@
+"""
+Agent runs API — start, inspect and stop UI-initiated Claude sessions.
+
+Endpoints:
+    POST   /assessments/{assessment_id}/agent/runs       — start a new run
+    GET    /assessments/{assessment_id}/agent/runs       — list runs (newest first)
+    GET    /agent/runs/{run_id}                          — full run (with transcript)
+    POST   /agent/runs/{run_id}/stop                     — cancel a running session
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from auth import get_current_user
+from database import get_db
+from models import User
+from schemas.agent_run import (
+    AgentRunCreate,
+    AgentRunResponse,
+    AgentRunSummary,
+    AgentRunListResponse,
+)
+from services.agent_service import AgentService, AgentServiceError
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+router = APIRouter(tags=["agent"])
+
+
+@router.post(
+    "/assessments/{assessment_id}/agent/runs",
+    response_model=AgentRunResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_agent_run(
+    assessment_id: int,
+    payload: AgentRunCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Start a new agent run for this assessment."""
+    service = AgentService(db)
+    try:
+        run = await service.create_run(
+            assessment_id=assessment_id,
+            user_id=current_user.id,
+            payload=payload,
+        )
+    except AgentServiceError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+        )
+    return run
+
+
+@router.get(
+    "/assessments/{assessment_id}/agent/runs",
+    response_model=AgentRunListResponse,
+)
+async def list_agent_runs(
+    assessment_id: int,
+    skip: int = 0,
+    limit: int = 50,
+    db: Session = Depends(get_db),
+):
+    """Return runs for this assessment (newest first, transcript omitted)."""
+    service = AgentService(db)
+    runs = service.list_runs(assessment_id, skip=skip, limit=limit)
+    total = service.count_runs(assessment_id)
+    return AgentRunListResponse(
+        runs=[AgentRunSummary.model_validate(r) for r in runs],
+        total=total,
+    )
+
+
+@router.get("/agent/runs/{run_id}", response_model=AgentRunResponse)
+async def get_agent_run(run_id: int, db: Session = Depends(get_db)):
+    """Return the full state of a single run, including transcript."""
+    service = AgentService(db)
+    run = service.get_run(run_id)
+    if run is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Agent run {run_id} not found",
+        )
+    return run
+
+
+@router.post("/agent/runs/{run_id}/stop", response_model=AgentRunResponse)
+async def stop_agent_run(run_id: int, db: Session = Depends(get_db)):
+    """Request cancellation of an active agent run."""
+    service = AgentService(db)
+    try:
+        run = await service.stop_run(run_id)
+    except AgentServiceError as exc:
+        # "not found" maps to 404, everything else to 400
+        code = (
+            status.HTTP_404_NOT_FOUND
+            if "not found" in str(exc).lower()
+            else status.HTTP_400_BAD_REQUEST
+        )
+        raise HTTPException(status_code=code, detail=str(exc))
+    return run

--- a/backend/main.py
+++ b/backend/main.py
@@ -14,7 +14,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from auth import get_current_user, require_admin
 from config import settings
 from database import init_db
-from api import assessments, cards, recon, sections, containers, folders, global_commands, search, system, credentials, websocket, workspace, pending_commands, context_documents, source_code, auth, reports, timeline, notifications, templates, users
+from api import assessments, cards, recon, sections, containers, folders, global_commands, search, system, credentials, websocket, workspace, pending_commands, context_documents, source_code, auth, reports, timeline, notifications, templates, users, agent
 from api import commands
 from api.commands import global_router as commands_global_router
 from utils.logger import setup_logging, get_logger
@@ -110,6 +110,7 @@ app.include_router(reports.router, prefix=settings.API_V1_PREFIX, dependencies=p
 app.include_router(timeline.router, prefix=settings.API_V1_PREFIX, dependencies=protected)
 app.include_router(notifications.router, prefix=settings.API_V1_PREFIX, dependencies=protected)
 app.include_router(templates.router, prefix=settings.API_V1_PREFIX, dependencies=protected)
+app.include_router(agent.router, prefix=settings.API_V1_PREFIX, dependencies=protected)
 
 # Admin-only router
 app.include_router(

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -14,6 +14,7 @@ from .pending_command import PendingCommand
 from .user import User
 from .timeline_event import TimelineEvent
 from .notification_config import NotificationConfig
+from .agent_run import AgentRun
 
 __all__ = [
     "Assessment",
@@ -29,5 +30,6 @@ __all__ = [
     "User",
     "TimelineEvent",
     "NotificationConfig",
+    "AgentRun",
 ]
 

--- a/backend/models/agent_run.py
+++ b/backend/models/agent_run.py
@@ -1,0 +1,65 @@
+"""
+Agent Run SQLAlchemy model
+
+Represents a headless Claude Code session launched from the UI against a
+specific assessment. The CLI path (`python3 aida.py`) does not create rows
+here — it remains a fully independent workflow.
+"""
+from sqlalchemy import Column, Integer, String, Text, TIMESTAMP, ForeignKey, Float
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.sql import func
+from sqlalchemy.orm import relationship
+from database import Base
+
+
+class AgentRun(Base):
+    __tablename__ = "agent_runs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    assessment_id = Column(
+        Integer,
+        ForeignKey("assessments.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    # User who started the run. SET NULL on delete so audit history survives
+    # user removal.
+    user_id = Column(
+        Integer,
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+
+    # User-provided goal / prompt fragment for this scan
+    goal = Column(Text, nullable=False)
+
+    # queued | running | completed | failed | stopped
+    status = Column(String(20), nullable=False, default="queued", index=True)
+
+    # Claude permission mode (e.g. "acceptEdits", "bypassPermissions")
+    permission_mode = Column(String(32), nullable=True)
+
+    # Model name reported by the SDK (e.g. "claude-sonnet-4-6")
+    model = Column(String(64), nullable=True)
+
+    # Populated on failure
+    error = Column(Text, nullable=True)
+
+    # Summary stats pulled from the SDK "result" message
+    num_turns = Column(Integer, nullable=True)
+    cost_usd = Column(Float, nullable=True)
+    duration_ms = Column(Integer, nullable=True)
+
+    # Full event stream captured from the SDK. List[dict]. Kept inline for
+    # now; can be split into a child table later without changing the API
+    # surface.
+    transcript = Column(JSONB, nullable=True)
+
+    created_at = Column(TIMESTAMP, server_default=func.now(), index=True)
+    started_at = Column(TIMESTAMP, nullable=True)
+    ended_at = Column(TIMESTAMP, nullable=True)
+
+    # Relationships
+    assessment = relationship("Assessment", back_populates="agent_runs")
+    user = relationship("User")

--- a/backend/models/assessment.py
+++ b/backend/models/assessment.py
@@ -50,4 +50,5 @@ class Assessment(Base):
     credentials_list = relationship("Credential", back_populates="assessment", cascade="all, delete-orphan")
     pending_commands = relationship("PendingCommand", back_populates="assessment", cascade="all, delete-orphan")
     timeline_events = relationship("TimelineEvent", back_populates="assessment", cascade="all, delete-orphan")
+    agent_runs = relationship("AgentRun", back_populates="assessment", cascade="all, delete-orphan")
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -19,3 +19,4 @@ alembic>=1.13.0
 slowapi>=0.1.9
 weasyprint>=62.0
 jinja2>=3.1.0
+claude-code-sdk>=0.0.20

--- a/backend/schemas/__init__.py
+++ b/backend/schemas/__init__.py
@@ -29,6 +29,12 @@ from .section import (
     SectionUpdate,
     SectionResponse
 )
+from .agent_run import (
+    AgentRunCreate,
+    AgentRunResponse,
+    AgentRunSummary,
+    AgentRunListResponse,
+)
 
 __all__ = [
     "AssessmentBase",
@@ -48,5 +54,9 @@ __all__ = [
     "SectionBase",
     "SectionCreate",
     "SectionUpdate",
-    "SectionResponse"
+    "SectionResponse",
+    "AgentRunCreate",
+    "AgentRunResponse",
+    "AgentRunSummary",
+    "AgentRunListResponse",
 ]

--- a/backend/schemas/agent_run.py
+++ b/backend/schemas/agent_run.py
@@ -1,0 +1,62 @@
+"""
+Agent Run Pydantic schemas
+"""
+from datetime import datetime
+from typing import Optional, List, Any, Dict
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class AgentRunCreate(BaseModel):
+    """Request payload for starting a new UI-initiated scan"""
+    goal: str = Field(..., min_length=1, description="What the agent should do")
+    permission_mode: Optional[str] = Field(
+        default=None,
+        description="Claude permission mode (e.g. acceptEdits, bypassPermissions)",
+    )
+    model: Optional[str] = Field(
+        default=None, description="Override Claude model id"
+    )
+
+
+class AgentRunResponse(BaseModel):
+    """Full state of an agent run"""
+    id: int
+    assessment_id: int
+    user_id: Optional[int]
+    goal: str
+    status: str
+    permission_mode: Optional[str]
+    model: Optional[str]
+    error: Optional[str]
+    num_turns: Optional[int]
+    cost_usd: Optional[float]
+    duration_ms: Optional[int]
+    transcript: Optional[List[Dict[str, Any]]]
+    created_at: datetime
+    started_at: Optional[datetime]
+    ended_at: Optional[datetime]
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AgentRunSummary(BaseModel):
+    """Lightweight view used in list endpoints (no transcript)"""
+    id: int
+    assessment_id: int
+    user_id: Optional[int]
+    goal: str
+    status: str
+    model: Optional[str]
+    num_turns: Optional[int]
+    cost_usd: Optional[float]
+    duration_ms: Optional[int]
+    created_at: datetime
+    started_at: Optional[datetime]
+    ended_at: Optional[datetime]
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AgentRunListResponse(BaseModel):
+    runs: List[AgentRunSummary]
+    total: int

--- a/backend/services/agent_service.py
+++ b/backend/services/agent_service.py
@@ -1,0 +1,143 @@
+"""
+Agent runs service — thin DB layer + hook into the AgentRunner.
+"""
+from __future__ import annotations
+
+from typing import List, Optional
+
+from sqlalchemy.orm import Session
+
+from agent import agent_runner
+from models import AgentRun, Assessment
+from schemas.agent_run import AgentRunCreate
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+ACTIVE_STATUSES = {"queued", "running"}
+
+
+class AgentServiceError(Exception):
+    """Domain-level error raised by AgentService; translated to HTTP in the API."""
+
+
+class AgentService:
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    # --- queries -------------------------------------------------------
+    def get_run(self, run_id: int) -> Optional[AgentRun]:
+        return self.db.query(AgentRun).filter(AgentRun.id == run_id).first()
+
+    def list_runs(
+        self,
+        assessment_id: int,
+        skip: int = 0,
+        limit: int = 50,
+    ) -> List[AgentRun]:
+        return (
+            self.db.query(AgentRun)
+            .filter(AgentRun.assessment_id == assessment_id)
+            .order_by(AgentRun.created_at.desc())
+            .offset(skip)
+            .limit(limit)
+            .all()
+        )
+
+    def count_runs(self, assessment_id: int) -> int:
+        return (
+            self.db.query(AgentRun)
+            .filter(AgentRun.assessment_id == assessment_id)
+            .count()
+        )
+
+    def has_active_run(self, assessment_id: int) -> bool:
+        return (
+            self.db.query(AgentRun)
+            .filter(
+                AgentRun.assessment_id == assessment_id,
+                AgentRun.status.in_(ACTIVE_STATUSES),
+            )
+            .first()
+            is not None
+        )
+
+    # --- commands ------------------------------------------------------
+    async def create_run(
+        self,
+        assessment_id: int,
+        user_id: Optional[int],
+        payload: AgentRunCreate,
+    ) -> AgentRun:
+        """Create a queued AgentRun row and schedule the session task."""
+        assessment = (
+            self.db.query(Assessment).filter(Assessment.id == assessment_id).first()
+        )
+        if assessment is None:
+            raise AgentServiceError(f"Assessment {assessment_id} not found")
+
+        # One active run per assessment keeps the mock path simple and
+        # prevents mixed transcripts in the UI. Relax later if needed.
+        if self.has_active_run(assessment_id):
+            raise AgentServiceError(
+                "An agent run is already active for this assessment"
+            )
+
+        run = AgentRun(
+            assessment_id=assessment_id,
+            user_id=user_id,
+            goal=payload.goal.strip(),
+            status="queued",
+            permission_mode=payload.permission_mode,
+            model=payload.model,
+        )
+        self.db.add(run)
+        self.db.commit()
+        self.db.refresh(run)
+
+        try:
+            await agent_runner.start(
+                run_id=run.id,
+                assessment_id=assessment_id,
+                goal=run.goal,
+                permission_mode=run.permission_mode,
+                model=run.model,
+            )
+        except Exception:
+            # If scheduling fails, don't leave a ghost "queued" row behind.
+            logger.exception("Failed to schedule agent run", run_id=run.id)
+            run.status = "failed"
+            run.error = "Failed to schedule session task"
+            self.db.commit()
+            raise
+
+        logger.info(
+            "Agent run created",
+            run_id=run.id,
+            assessment_id=assessment_id,
+            user_id=user_id,
+        )
+        return run
+
+    async def stop_run(self, run_id: int) -> AgentRun:
+        run = self.get_run(run_id)
+        if run is None:
+            raise AgentServiceError(f"Agent run {run_id} not found")
+        if run.status not in ACTIVE_STATUSES:
+            raise AgentServiceError(
+                f"Agent run {run_id} is not active (status={run.status})"
+            )
+
+        cancelled = await agent_runner.stop(run_id)
+        if not cancelled:
+            # Task isn't in the registry (e.g. process restart after crash).
+            # Reconcile the DB state so the UI doesn't show a stuck row.
+            from datetime import datetime, timezone
+
+            run.status = "stopped"
+            run.ended_at = datetime.now(timezone.utc).replace(tzinfo=None)
+            self.db.commit()
+            self.db.refresh(run)
+
+        return run

--- a/backend/websocket/events.py
+++ b/backend/websocket/events.py
@@ -49,6 +49,13 @@ class EventType(str, Enum):
     FOLDER_UPDATED = "folder_updated"
     FOLDER_DELETED = "folder_deleted"
 
+    # Agent run events (UI-initiated Claude sessions)
+    AGENT_RUN_STARTED = "agent_run_started"
+    AGENT_RUN_MESSAGE = "agent_run_message"
+    AGENT_RUN_COMPLETED = "agent_run_completed"
+    AGENT_RUN_FAILED = "agent_run_failed"
+    AGENT_RUN_STOPPED = "agent_run_stopped"
+
     # System events
     SYSTEM_STATUS_CHANGED = "system_status_changed"
     ERROR = "error"
@@ -192,6 +199,51 @@ def event_credential_added(assessment_id: int, credential_data: dict) -> dict:
         EventType.CREDENTIAL_ADDED,
         {"credential": credential_data},
         assessment_id=assessment_id
+    )
+
+
+def event_agent_run_started(assessment_id: int, run_data: dict) -> dict:
+    """Create agent_run_started event"""
+    return create_event(
+        EventType.AGENT_RUN_STARTED,
+        {"run": run_data},
+        assessment_id=assessment_id,
+    )
+
+
+def event_agent_run_message(assessment_id: int, run_id: int, message: dict) -> dict:
+    """Create agent_run_message event — one SDK-level event in the stream"""
+    return create_event(
+        EventType.AGENT_RUN_MESSAGE,
+        {"run_id": run_id, "message": message},
+        assessment_id=assessment_id,
+    )
+
+
+def event_agent_run_completed(assessment_id: int, run_data: dict) -> dict:
+    """Create agent_run_completed event"""
+    return create_event(
+        EventType.AGENT_RUN_COMPLETED,
+        {"run": run_data},
+        assessment_id=assessment_id,
+    )
+
+
+def event_agent_run_failed(assessment_id: int, run_id: int, error: str) -> dict:
+    """Create agent_run_failed event"""
+    return create_event(
+        EventType.AGENT_RUN_FAILED,
+        {"run_id": run_id, "error": error},
+        assessment_id=assessment_id,
+    )
+
+
+def event_agent_run_stopped(assessment_id: int, run_id: int) -> dict:
+    """Create agent_run_stopped event"""
+    return create_event(
+        EventType.AGENT_RUN_STOPPED,
+        {"run_id": run_id},
+        assessment_id=assessment_id,
     )
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,9 @@ services:
       # Route docker CLI through the socket proxy instead of raw daemon socket.
       # The proxy only allows inspect/exec/start — no run/create/volumes.
       DOCKER_HOST: tcp://docker-proxy:2375
+      # CLAUDE_CODE_OAUTH_TOKEN is loaded from backend/.env via env_file above.
+      # Generate it once on the host with `claude setup-token` and paste the
+      # result into backend/.env. Absent → AgentSession falls back to mock.
     ports:
       # Bind to localhost only — the API must not be reachable from the LAN.
       - "127.0.0.1:8000:8000"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,19 +1,21 @@
 {
   "name": "aida-frontend",
-  "version": "0.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aida-frontend",
-      "version": "0.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "axios": "^1.15.0",
         "lucide-react": "^0.556.0",
         "prop-types": "^15.8.1",
         "react": "^19.1.2",
         "react-dom": "^19.1.2",
-        "react-router-dom": "^7.9.3"
+        "react-markdown": "^9.1.0",
+        "react-router-dom": "^7.9.3",
+        "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
@@ -1451,18 +1453,59 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/prop-types": {
@@ -1476,7 +1519,6 @@
       "version": "19.1.16",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.16.tgz",
       "integrity": "sha512-WBM/nDbEZmDUORKnh5i1bTnAz6vTohUf9b8esSMu+b24+srbaxa04UbJgWx78CVfNXA20sNu0odEIluZDFdCog==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -1491,6 +1533,18 @@
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.0.4",
@@ -1685,6 +1739,16 @@
         "proxy-from-env": "^2.1.0"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1827,6 +1891,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1842,6 +1916,46 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/chokidar": {
@@ -1914,6 +2028,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -1979,14 +2103,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1998,6 +2120,19 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/deep-is": {
@@ -2014,6 +2149,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/didyoumean": {
@@ -2343,6 +2500,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2352,6 +2519,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -2768,6 +2941,56 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2805,6 +3028,36 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -2832,6 +3085,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-extglob": {
@@ -2867,6 +3130,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -2875,6 +3148,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isexe": {
@@ -3043,6 +3328,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -3074,6 +3369,16 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3081,6 +3386,288 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/merge2": {
@@ -3092,6 +3679,569 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -3168,7 +4318,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -3324,6 +4473,31 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -3600,6 +4774,16 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
@@ -3666,6 +4850,33 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/react-markdown": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-9.1.0.tgz",
+      "integrity": "sha512-xaijuJB0kzGiUdG7nc2MOMDUDBWPyGAjZtUrow9XxUeua8IqeP+VlIfAZ3bphpcLTnSZXz6z9jcVC/TCwbfgdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -3749,6 +4960,72 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/resolve": {
@@ -3927,6 +5204,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
@@ -3991,6 +5278,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
@@ -4042,6 +5343,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/sucrase": {
@@ -4184,6 +5503,26 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -4202,6 +5541,93 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -4251,6 +5677,34 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/vite": {
       "version": "7.2.6",
@@ -4466,6 +5920,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,9 @@
     "prop-types": "^15.8.1",
     "react": "^19.1.2",
     "react-dom": "^19.1.2",
-    "react-router-dom": "^7.9.3"
+    "react-markdown": "^9.1.0",
+    "react-router-dom": "^7.9.3",
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",

--- a/frontend/src/components/assessment/AgentRunPanel.jsx
+++ b/frontend/src/components/assessment/AgentRunPanel.jsx
@@ -1,0 +1,670 @@
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import {
+  Play,
+  X,
+  Loader2,
+  Cpu,
+  Terminal,
+  Activity,
+  Check,
+  AlertCircle,
+  ChevronDown,
+  ChevronRight,
+  Plus,
+} from '../icons';
+import agentService from '../../services/agentService';
+
+// Collapse threshold — anything longer gets a "click to expand" wrapper.
+const COLLAPSE_CHAR_LIMIT = 600;
+
+const ACTIVE_STATUSES = new Set(['queued', 'running']);
+
+const STATUS_STYLES = {
+  queued: 'bg-neutral-200 text-neutral-700 dark:bg-neutral-700 dark:text-neutral-200',
+  running: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300',
+  completed: 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300',
+  failed: 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300',
+  stopped: 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300',
+};
+
+function StatusChip({ status }) {
+  const cls = STATUS_STYLES[status] || STATUS_STYLES.queued;
+  return (
+    <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium ${cls}`}>
+      {status === 'running' && <Loader2 className="w-3 h-3 animate-spin" />}
+      {status}
+    </span>
+  );
+}
+
+function formatRelative(iso) {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  const diff = Date.now() - d.getTime();
+  const s = Math.floor(diff / 1000);
+  if (s < 60) return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  return d.toLocaleString();
+}
+
+function formatDuration(ms) {
+  if (ms == null) return '—';
+  const s = ms / 1000;
+  if (s < 60) return `${s.toFixed(1)}s`;
+  const m = Math.floor(s / 60);
+  const rem = Math.round(s - m * 60);
+  return `${m}m ${rem}s`;
+}
+
+function MarkdownText({ text }) {
+  return (
+    <div className="markdown-body text-sm text-neutral-800 dark:text-neutral-200 leading-relaxed">
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          p: ({ node, ...props }) => <p className="my-1" {...props} />,
+          h1: ({ node, ...props }) => <h1 className="text-base font-semibold mt-3 mb-1" {...props} />,
+          h2: ({ node, ...props }) => <h2 className="text-sm font-semibold mt-3 mb-1" {...props} />,
+          h3: ({ node, ...props }) => <h3 className="text-sm font-semibold mt-2 mb-1" {...props} />,
+          ul: ({ node, ...props }) => <ul className="list-disc pl-5 my-1 space-y-0.5" {...props} />,
+          ol: ({ node, ...props }) => <ol className="list-decimal pl-5 my-1 space-y-0.5" {...props} />,
+          li: ({ node, ...props }) => <li className="leading-snug" {...props} />,
+          a: ({ node, ...props }) => (
+            <a className="text-primary-600 dark:text-primary-400 underline" target="_blank" rel="noreferrer" {...props} />
+          ),
+          code: ({ node, inline, className, children, ...props }) => {
+            if (inline) {
+              return (
+                <code
+                  className="px-1 py-0.5 rounded bg-neutral-200/70 dark:bg-neutral-700/60 font-mono text-[12px]"
+                  {...props}
+                >
+                  {children}
+                </code>
+              );
+            }
+            return (
+              <code className="block font-mono text-[12px] whitespace-pre-wrap" {...props}>
+                {children}
+              </code>
+            );
+          },
+          pre: ({ node, ...props }) => (
+            <pre
+              className="my-2 px-3 py-2 rounded-md bg-neutral-900 text-neutral-100 dark:bg-black/60 overflow-x-auto text-[12px]"
+              {...props}
+            />
+          ),
+          blockquote: ({ node, ...props }) => (
+            <blockquote className="border-l-2 border-neutral-300 dark:border-neutral-600 pl-3 italic my-1" {...props} />
+          ),
+          table: ({ node, ...props }) => (
+            <div className="overflow-x-auto my-2">
+              <table className="min-w-full text-[12px] border-collapse" {...props} />
+            </div>
+          ),
+          th: ({ node, ...props }) => (
+            <th className="border border-neutral-300 dark:border-neutral-600 px-2 py-1 bg-neutral-100 dark:bg-neutral-800" {...props} />
+          ),
+          td: ({ node, ...props }) => (
+            <td className="border border-neutral-300 dark:border-neutral-700 px-2 py-1 align-top" {...props} />
+          ),
+        }}
+      >
+        {text}
+      </ReactMarkdown>
+    </div>
+  );
+}
+
+function syntaxHighlightJSON(jsonStr) {
+  // Small inline colorizer — avoids pulling in a full highlighter. Good enough
+  // for tool input/result JSON, which is the only thing we feed into it.
+  const escaped = jsonStr
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+  return escaped.replace(
+    /("(?:\\.|[^"\\])*"(?:\s*:)?)|(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)|(\btrue\b|\bfalse\b)|(\bnull\b)/g,
+    (match, str, num, bool, nul) => {
+      if (str) {
+        const isKey = str.endsWith(':') || /"\s*:$/.test(str);
+        return `<span class="${isKey
+          ? 'text-sky-600 dark:text-sky-300'
+          : 'text-emerald-700 dark:text-emerald-300'}">${str}</span>`;
+      }
+      if (num) return `<span class="text-amber-600 dark:text-amber-300">${num}</span>`;
+      if (bool) return `<span class="text-purple-600 dark:text-purple-300">${bool}</span>`;
+      if (nul) return `<span class="text-neutral-500">${nul}</span>`;
+      return match;
+    },
+  );
+}
+
+function HighlightedJSON({ value }) {
+  const jsonStr = useMemo(() => {
+    try {
+      return typeof value === 'string' ? value : JSON.stringify(value, null, 2);
+    } catch {
+      return String(value);
+    }
+  }, [value]);
+  const html = useMemo(() => syntaxHighlightJSON(jsonStr), [jsonStr]);
+  return (
+    <pre
+      className="font-mono text-[11px] whitespace-pre-wrap break-words"
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+}
+
+function CollapsibleBlock({ children, charLen, label = 'output' }) {
+  const longByDefault = charLen > COLLAPSE_CHAR_LIMIT;
+  const [open, setOpen] = useState(!longByDefault);
+  if (!longByDefault) return children;
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex items-center gap-1 text-[11px] text-neutral-500 hover:text-neutral-800 dark:hover:text-neutral-200 mb-1"
+      >
+        {open ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
+        <span>{open ? 'Hide' : `Show ${charLen.toLocaleString()} chars of ${label}`}</span>
+      </button>
+      {open && children}
+    </div>
+  );
+}
+
+function TranscriptEvent({ event }) {
+  const type = event.type;
+  if (type === 'assistant_text') {
+    const len = (event.text || '').length;
+    return (
+      <div className="flex gap-2">
+        <span className="text-primary-600 dark:text-primary-400 font-mono text-xs shrink-0 pt-0.5">ai</span>
+        <div className="flex-1 min-w-0">
+          <CollapsibleBlock charLen={len} label="response">
+            <MarkdownText text={event.text || ''} />
+          </CollapsibleBlock>
+        </div>
+      </div>
+    );
+  }
+  if (type === 'tool_use') {
+    const inputStr = event.input ? JSON.stringify(event.input, null, 2) : '';
+    return (
+      <div className="flex gap-2 text-xs">
+        <span className="text-amber-600 dark:text-amber-400 shrink-0 font-mono pt-0.5">tool</span>
+        <div className="flex-1 min-w-0">
+          <div className="font-mono text-neutral-700 dark:text-neutral-300">{event.name}</div>
+          {event.input && (
+            <div className="mt-0.5">
+              <CollapsibleBlock charLen={inputStr.length} label="input">
+                <HighlightedJSON value={event.input} />
+              </CollapsibleBlock>
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  }
+  if (type === 'tool_result') {
+    const raw = event.content;
+    const text = typeof raw === 'string' ? raw : JSON.stringify(raw, null, 2);
+    const looksLikeJson =
+      typeof raw !== 'string' ||
+      (raw.trim().startsWith('{') || raw.trim().startsWith('['));
+    return (
+      <div className="flex gap-2 text-xs">
+        <span className={`shrink-0 pt-0.5 font-mono ${event.is_error ? 'text-red-500' : 'text-green-600 dark:text-green-400'}`}>
+          ←
+        </span>
+        <div className="flex-1 min-w-0">
+          <CollapsibleBlock charLen={(text || '').length} label="output">
+            {looksLikeJson ? (
+              <HighlightedJSON value={raw} />
+            ) : (
+              <pre className="font-mono text-[11px] whitespace-pre-wrap break-words text-neutral-600 dark:text-neutral-300">
+                {text}
+              </pre>
+            )}
+          </CollapsibleBlock>
+        </div>
+      </div>
+    );
+  }
+  if (type === 'system_init') {
+    return (
+      <div className="text-[11px] text-neutral-500 dark:text-neutral-400 font-mono">
+        session {event.session_id} · {event.model}
+      </div>
+    );
+  }
+  if (type === 'result') {
+    return (
+      <div className="text-[11px] text-neutral-500 dark:text-neutral-400 font-mono">
+        turns={event.num_turns} · duration={formatDuration(event.duration_ms)} · cost=${(event.total_cost_usd || 0).toFixed(4)}
+      </div>
+    );
+  }
+  return (
+    <pre className="text-xs text-neutral-500 dark:text-neutral-400 whitespace-pre-wrap">
+      {JSON.stringify(event, null, 2)}
+    </pre>
+  );
+}
+
+function TranscriptList({ events }) {
+  if (!events || events.length === 0) {
+    return <div className="text-xs text-neutral-400 italic">No messages yet…</div>;
+  }
+  return (
+    <div className="space-y-2">
+      {events.map((ev, idx) => (
+        <TranscriptEvent key={idx} event={ev} />
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Scroll container that follows new content while the user is near the bottom,
+ * but respects manual scroll-up (so reading earlier events isn't yanked away).
+ */
+function AutoScroll({ deps = [], className = '', children }) {
+  const ref = useRef(null);
+  const stick = useRef(true);
+
+  const onScroll = () => {
+    const el = ref.current;
+    if (!el) return;
+    const slack = 40; // px
+    stick.current = el.scrollHeight - el.scrollTop - el.clientHeight < slack;
+  };
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || !stick.current) return;
+    // Defer to next frame so layout has settled after new content mounts.
+    const id = requestAnimationFrame(() => {
+      el.scrollTop = el.scrollHeight;
+    });
+    return () => cancelAnimationFrame(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+
+  return (
+    <div ref={ref} onScroll={onScroll} className={className}>
+      {children}
+    </div>
+  );
+}
+
+const MODEL_OPTIONS = [
+  { id: '', label: 'Default (Sonnet 4.6)', hint: 'Balanced speed and depth' },
+  { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6', hint: 'Balanced speed and depth' },
+  { id: 'claude-opus-4-7', label: 'Opus 4.7', hint: 'Deepest reasoning, slower, pricier' },
+  { id: 'claude-haiku-4-5', label: 'Haiku 4.5', hint: 'Fastest, cheapest — light tasks' },
+];
+
+function StartRunModal({ onClose, onSubmit, busy }) {
+  const [goal, setGoal] = useState('');
+  const [model, setModel] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    const trimmed = goal.trim();
+    if (!trimmed) {
+      setError('Goal is required');
+      return;
+    }
+    try {
+      await onSubmit({ goal: trimmed, model: model || undefined });
+    } catch (err) {
+      setError(err?.response?.data?.detail || err.message || 'Failed to start run');
+    }
+  };
+
+  const hint = MODEL_OPTIONS.find((m) => m.id === model)?.hint;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 dark:bg-black/70 backdrop-blur-sm">
+      <div className="bg-white dark:bg-neutral-800 rounded-xl shadow-strong max-w-lg w-full mx-4">
+        <div className="flex items-center justify-between px-5 py-3 border-b border-neutral-200 dark:border-neutral-700">
+          <div className="flex items-center gap-2">
+            <Cpu className="w-4 h-4 text-primary-500" />
+            <h3 className="text-sm font-semibold text-neutral-900 dark:text-neutral-100">Start AI scan</h3>
+          </div>
+          <button onClick={onClose} className="text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-200">
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+        <form onSubmit={handleSubmit} className="px-5 py-4 space-y-3">
+          <div>
+            <label className="block text-xs font-medium text-neutral-700 dark:text-neutral-300 mb-1">Goal</label>
+            <textarea
+              autoFocus
+              value={goal}
+              onChange={(e) => setGoal(e.target.value)}
+              rows={4}
+              placeholder="e.g. Enumerate services on the in-scope hosts and flag anything with known CVEs"
+              className="w-full px-3 py-2 text-sm rounded-lg border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-900 text-neutral-900 dark:text-neutral-100 focus:outline-none focus:ring-2 focus:ring-primary-500"
+            />
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-neutral-700 dark:text-neutral-300 mb-1">Model</label>
+            <select
+              value={model}
+              onChange={(e) => setModel(e.target.value)}
+              className="w-full px-3 py-2 text-sm rounded-lg border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-900 text-neutral-900 dark:text-neutral-100 focus:outline-none focus:ring-2 focus:ring-primary-500"
+            >
+              {MODEL_OPTIONS.map((m) => (
+                <option key={m.id || 'default'} value={m.id}>{m.label}</option>
+              ))}
+            </select>
+            {hint && (
+              <p className="text-[11px] text-neutral-500 dark:text-neutral-400 mt-1">{hint}</p>
+            )}
+          </div>
+          <p className="text-[11px] text-neutral-500 dark:text-neutral-400">
+            The agent runs headlessly in the backend. You can watch its transcript live and stop it at any time.
+          </p>
+          {error && (
+            <div className="flex items-start gap-2 px-3 py-2 rounded bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300 text-xs">
+              <AlertCircle className="w-3.5 h-3.5 mt-0.5 shrink-0" />
+              <span>{error}</span>
+            </div>
+          )}
+          <div className="flex justify-end gap-2 pt-2">
+            <button type="button" onClick={onClose} className="btn btn-secondary btn-sm" disabled={busy}>
+              Cancel
+            </button>
+            <button type="submit" className="btn btn-primary btn-sm" disabled={busy}>
+              {busy ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Play className="w-3.5 h-3.5" />}
+              <span>Start</span>
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * AgentRunPanel — UI-initiated Claude sessions for one assessment.
+ *
+ * Subscribes to WS events to update the active run's status and transcript
+ * in real time. Full transcripts for completed runs are lazy-loaded on expand.
+ */
+export default function AgentRunPanel({ assessmentId, subscribe }) {
+  const [runs, setRuns] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [showModal, setShowModal] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [expandedId, setExpandedId] = useState(null);
+  const [expandedTranscript, setExpandedTranscript] = useState(null);
+  const [stopping, setStopping] = useState(false);
+
+  // Live transcript buffer keyed by run_id, so the active run fills in
+  // events as WS messages arrive even before we refresh the list.
+  const liveTranscripts = useRef({});
+
+  const activeRun = runs.find((r) => ACTIVE_STATUSES.has(r.status)) || null;
+
+  const loadRuns = useCallback(async () => {
+    try {
+      const data = await agentService.list(assessmentId);
+      setRuns(data.runs || []);
+    } catch (err) {
+      console.error('Failed to load agent runs', err);
+    } finally {
+      setLoading(false);
+    }
+  }, [assessmentId]);
+
+  useEffect(() => {
+    loadRuns();
+  }, [loadRuns]);
+
+  // WebSocket subscriptions — maintain a live transcript for the active run
+  // and update status rows as events land.
+  useEffect(() => {
+    if (!subscribe) return;
+
+    const upsertRun = (run) => {
+      if (!run || run.assessment_id !== Number(assessmentId)) return;
+      setRuns((prev) => {
+        const idx = prev.findIndex((r) => r.id === run.id);
+        if (idx === -1) return [run, ...prev];
+        const next = [...prev];
+        next[idx] = { ...next[idx], ...run };
+        return next;
+      });
+    };
+
+    const unsubStarted = subscribe('agent_run_started', (data) => {
+      liveTranscripts.current[data.run.id] = [];
+      upsertRun(data.run);
+    });
+
+    const unsubMessage = subscribe('agent_run_message', (data) => {
+      const buf = liveTranscripts.current[data.run_id] || [];
+      liveTranscripts.current[data.run_id] = [...buf, data.message];
+      // Trigger a re-render by touching runs state with a no-op reference
+      // bump so the panel reflects the new transcript length.
+      setRuns((prev) => prev.map((r) => (r.id === data.run_id ? { ...r } : r)));
+    });
+
+    const unsubCompleted = subscribe('agent_run_completed', (data) => {
+      upsertRun(data.run);
+    });
+
+    const unsubFailed = subscribe('agent_run_failed', (data) => {
+      setRuns((prev) =>
+        prev.map((r) =>
+          r.id === data.run_id ? { ...r, status: 'failed', error: data.error } : r
+        )
+      );
+    });
+
+    const unsubStopped = subscribe('agent_run_stopped', (data) => {
+      setRuns((prev) =>
+        prev.map((r) => (r.id === data.run_id ? { ...r, status: 'stopped' } : r))
+      );
+    });
+
+    return () => {
+      unsubStarted();
+      unsubMessage();
+      unsubCompleted();
+      unsubFailed();
+      unsubStopped();
+    };
+  }, [subscribe, assessmentId]);
+
+  const handleStart = async ({ goal, model }) => {
+    setSubmitting(true);
+    try {
+      const run = await agentService.create(assessmentId, { goal, model });
+      liveTranscripts.current[run.id] = [];
+      setRuns((prev) => [run, ...prev]);
+      setShowModal(false);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleStop = async (runId) => {
+    setStopping(true);
+    try {
+      await agentService.stop(runId);
+    } catch (err) {
+      console.error('Failed to stop run', err);
+    } finally {
+      setStopping(false);
+    }
+  };
+
+  const toggleExpand = async (runId) => {
+    if (expandedId === runId) {
+      setExpandedId(null);
+      setExpandedTranscript(null);
+      return;
+    }
+    setExpandedId(runId);
+    setExpandedTranscript(null);
+    try {
+      const full = await agentService.get(runId);
+      setExpandedTranscript(full.transcript || []);
+    } catch (err) {
+      console.error('Failed to load transcript', err);
+      setExpandedTranscript([]);
+    }
+  };
+
+  return (
+    <div className="bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 rounded-lg">
+      <div className="px-4 py-3 border-b border-neutral-200 dark:border-neutral-700 bg-gray-50 dark:bg-neutral-900">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Cpu className="w-4 h-4 text-primary-500" />
+            <h2 className="text-sm font-semibold text-gray-800 dark:text-neutral-100">AI Scans</h2>
+            <span className="text-xs text-gray-500 dark:text-neutral-400">
+              {runs.length} {runs.length === 1 ? 'run' : 'runs'}
+            </span>
+          </div>
+          <button
+            onClick={() => setShowModal(true)}
+            disabled={!!activeRun}
+            className="btn btn-primary btn-sm"
+            title={activeRun ? 'A scan is already running' : 'Start a new AI scan'}
+          >
+            <Plus className="w-3.5 h-3.5" />
+            <span>New scan</span>
+          </button>
+        </div>
+      </div>
+
+      <div className="p-4 space-y-3">
+        {loading && (
+          <div className="flex items-center gap-2 text-xs text-neutral-500 dark:text-neutral-400">
+            <Loader2 className="w-3.5 h-3.5 animate-spin" />
+            Loading runs…
+          </div>
+        )}
+
+        {!loading && activeRun && (
+          <div className="border border-primary-200 dark:border-primary-800 rounded-lg overflow-hidden">
+            <div className="px-3 py-2 bg-primary-50 dark:bg-primary-900/20 flex items-center justify-between">
+              <div className="flex items-center gap-2 min-w-0">
+                <Activity className="w-3.5 h-3.5 text-primary-500 shrink-0" />
+                <StatusChip status={activeRun.status} />
+                <span className="text-xs text-neutral-700 dark:text-neutral-200 truncate">
+                  {activeRun.goal}
+                </span>
+              </div>
+              <button
+                onClick={() => handleStop(activeRun.id)}
+                disabled={stopping}
+                className="btn btn-secondary btn-sm"
+                title="Stop run"
+              >
+                {stopping ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <X className="w-3.5 h-3.5" />}
+                <span>Stop</span>
+              </button>
+            </div>
+            <AutoScroll
+              deps={[(liveTranscripts.current[activeRun.id] || []).length]}
+              className="px-3 py-3 max-h-80 overflow-y-auto bg-neutral-50 dark:bg-neutral-900/40"
+            >
+              <TranscriptList events={liveTranscripts.current[activeRun.id] || []} />
+            </AutoScroll>
+          </div>
+        )}
+
+        {!loading && runs.length === 0 && (
+          <div className="py-8 text-center">
+            <Terminal className="w-8 h-8 mx-auto text-neutral-300 dark:text-neutral-600 mb-2" />
+            <p className="text-xs text-neutral-500 dark:text-neutral-400">
+              No AI scans yet. Start one to let the agent work autonomously against this assessment.
+            </p>
+          </div>
+        )}
+
+        {!loading && runs.filter((r) => !ACTIVE_STATUSES.has(r.status)).length > 0 && (
+          <div className="border border-neutral-200 dark:border-neutral-700 rounded-lg divide-y divide-neutral-200 dark:divide-neutral-700">
+            {runs
+              .filter((r) => !ACTIVE_STATUSES.has(r.status))
+              .map((run) => {
+                const expanded = expandedId === run.id;
+                return (
+                  <div key={run.id}>
+                    <button
+                      onClick={() => toggleExpand(run.id)}
+                      className="w-full flex items-center gap-3 px-3 py-2 text-left hover:bg-neutral-50 dark:hover:bg-neutral-900/40"
+                    >
+                      {expanded ? (
+                        <ChevronDown className="w-3.5 h-3.5 text-neutral-400 shrink-0" />
+                      ) : (
+                        <ChevronRight className="w-3.5 h-3.5 text-neutral-400 shrink-0" />
+                      )}
+                      <StatusChip status={run.status} />
+                      <span className="flex-1 min-w-0 truncate text-xs text-neutral-700 dark:text-neutral-200">
+                        {run.goal}
+                      </span>
+                      <span className="text-[11px] text-neutral-500 dark:text-neutral-400 shrink-0">
+                        {formatDuration(run.duration_ms)}
+                      </span>
+                      <span className="text-[11px] text-neutral-500 dark:text-neutral-400 shrink-0 w-20 text-right">
+                        {formatRelative(run.created_at)}
+                      </span>
+                    </button>
+                    {expanded && (
+                      <div className="px-3 py-3 bg-neutral-50 dark:bg-neutral-900/40 border-t border-neutral-200 dark:border-neutral-700">
+                        {run.status === 'failed' && run.error && (
+                          <div className="mb-2 flex items-start gap-2 px-2 py-1.5 rounded bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300 text-xs">
+                            <AlertCircle className="w-3.5 h-3.5 mt-0.5 shrink-0" />
+                            <span className="font-mono break-all">{run.error}</span>
+                          </div>
+                        )}
+                        {expandedTranscript === null ? (
+                          <div className="flex items-center gap-2 text-xs text-neutral-500 dark:text-neutral-400">
+                            <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                            Loading transcript…
+                          </div>
+                        ) : (
+                          <AutoScroll
+                            deps={[expandedTranscript.length]}
+                            className="max-h-80 overflow-y-auto"
+                          >
+                            <TranscriptList events={expandedTranscript} />
+                          </AutoScroll>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+          </div>
+        )}
+      </div>
+
+      {showModal && (
+        <StartRunModal
+          onClose={() => setShowModal(false)}
+          onSubmit={handleStart}
+          busy={submitting}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/AssessmentDetail.jsx
+++ b/frontend/src/pages/AssessmentDetail.jsx
@@ -13,6 +13,7 @@ import ImportScanModal from '../components/assessment/ImportScanModal';
 import CredentialsManager from '../components/assessment/CredentialsManager';
 import ContextDocumentsPanel from '../components/assessment/ContextDocumentsPanel';
 import AttackTimeline from '../components/assessment/AttackTimeline';
+import AgentRunPanel from '../components/assessment/AgentRunPanel';
 import SendReportModal from '../components/assessment/SendReportModal';
 
 import ChangeContainerModal from '../components/workspace/ChangeContainerModal';
@@ -1016,6 +1017,9 @@ const AssessmentDetail = () => {
           />
         )}
       </div>
+
+      {/* AI Scans - UI-initiated headless Claude sessions */}
+      <AgentRunPanel assessmentId={parseInt(id)} subscribe={subscribe} />
 
       {/* Command History - Version compacte et navigable */}
       <div className="bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 rounded-lg">

--- a/frontend/src/services/agentService.js
+++ b/frontend/src/services/agentService.js
@@ -1,0 +1,42 @@
+/**
+ * Agent runs API service — UI-initiated Claude sessions.
+ */
+import apiClient from './api';
+
+export const agentService = {
+  /** List runs for an assessment (newest first, transcript omitted). */
+  list: async (assessmentId, { skip = 0, limit = 50 } = {}) => {
+    const response = await apiClient.get(
+      `/assessments/${assessmentId}/agent/runs`,
+      { params: { skip, limit } }
+    );
+    return response.data;
+  },
+
+  /** Full run state including transcript. */
+  get: async (runId) => {
+    const response = await apiClient.get(`/agent/runs/${runId}`);
+    return response.data;
+  },
+
+  /** Start a new run. */
+  create: async (assessmentId, { goal, permissionMode, model } = {}) => {
+    const response = await apiClient.post(
+      `/assessments/${assessmentId}/agent/runs`,
+      {
+        goal,
+        permission_mode: permissionMode || null,
+        model: model || null,
+      }
+    );
+    return response.data;
+  },
+
+  /** Request cancellation of a running session. */
+  stop: async (runId) => {
+    const response = await apiClient.post(`/agent/runs/${runId}/stop`);
+    return response.data;
+  },
+};
+
+export default agentService;


### PR DESCRIPTION
Adds an "AI Scans" panel to each assessment page that spawns a fully headless Claude session in the backend, streams its thinking / tool_use / tool_result events to the UI over WebSocket, and persists the full transcript in Postgres. Runs in parallel to the existing `python3 aida.py` CLI workflow — both paths share the same MCP server and DB.

Auth uses the Claude Code OAuth token (Max subscription) via CLAUDE_CODE_OAUTH_TOKEN — no API key required. Absent → session falls back to a scripted mock so the panel is demoable without credentials.

Backend
  * models/agent_run.py — new table (status, JSONB transcript, cost, turns, duration, FK to assessment/user)
  * agent/runner.py — asyncio.Task registry, one active run per assessment
  * agent/session.py — SDK driver: maps SystemMessage / AssistantMessage / ToolUse / ToolResult / ResultMessage into transcript events, handles cancel/stop, mock fallback
  * agent/mcp_config.py + preprompt.py — wires the existing AIDA MCP server as a stdio subprocess and loads Docs/PrePrompt.txt
  * agent/_sdk_compat.py — forward-compat shim for new SDK message types (e.g. rate_limit_event) so the stream keeps flowing
  * api/agent.py — POST/GET create/list/get/stop endpoints
  * websocket/events.py — 5 new event types for live streaming
  * Dockerfile — installs Node 20 + @anthropic-ai/claude-code CLI and wraps it with a setpriv shim; the CLI refuses --dangerously-skip-permissions under root, so the claude subprocess is re-exec'd as a dedicated non-root user
  * docker-compose.yml — CLAUDE_CODE_OAUTH_TOKEN is now loaded from backend/.env via env_file

Frontend
  * AgentRunPanel.jsx — live transcript, Start / Stop, model picker (Sonnet 4.6 / Opus 4.7 / Haiku 4.5), markdown rendering for assistant replies, JSON syntax highlighting for tool input/output, auto-collapse of long outputs, sticky autoscroll
  * agentService.js — thin axios wrapper
  * AssessmentDetail.jsx — mounts the panel under each assessment
  * package.json — react-markdown, remark-gfm

README — new "UI-Initiated Scans" section with the `claude setup-token` flow and behavior notes.